### PR TITLE
feat: add environment settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Optional API key for CoinGecko
+COINGECKO_API_KEY=
+
+# Directories for storing data, models and logs
+DATA_DIR=./data
+MODELS_DIR=./models
+LOGS_DIR=./logs
+
+# Comma-separated list of crypto symbols to track
+SYMBOLS=BTC,ETH
+
+# Fiat currency for prices
+FIAT=USD

--- a/configs/settings.py
+++ b/configs/settings.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    coingecko_api_key: Optional[str] = None
+    data_dir: Path = Path("./data")
+    models_dir: Path = Path("./models")
+    logs_dir: Path = Path("./logs")
+    symbols: List[str] = Field(default_factory=lambda: ["BTC", "ETH"])
+    fiat: str = "USD"
+
+    @field_validator("symbols", mode="before")
+    def split_symbols(cls, v: str | List[str]):
+        if isinstance(v, str):
+            return [s.strip() for s in v.split(",") if s.strip()]
+        return v
+
+    @field_validator("data_dir", "models_dir", "logs_dir", mode="before")
+    def ensure_directory(cls, v: str | Path) -> Path:
+        path = Path(v)
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")

--- a/src/utils/env.py
+++ b/src/utils/env.py
@@ -1,0 +1,9 @@
+from functools import lru_cache
+
+from configs.settings import Settings
+
+
+@lru_cache(maxsize=1)
+def load_settings() -> Settings:
+    """Load application settings, returning a singleton instance."""
+    return Settings()


### PR DESCRIPTION
## Summary
- add Settings model for reading `.env`
- provide `load_settings` helper
- include `.env.example` template

## Testing
- `python -m py_compile configs/settings.py src/utils/env.py`
- `python - <<'PY'
from src.utils.env import load_settings
s = load_settings()
print('symbols:', s.symbols)
print('directories:', s.data_dir, s.models_dir, s.logs_dir)
print('dirs exist:', s.data_dir.exists(), s.models_dir.exists(), s.logs_dir.exists())
PY`


------
https://chatgpt.com/codex/tasks/task_e_6897d948fcd48328b94c578bd4355c0c