### PR TITLE
Add feature generation utilities without look-ahead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.pytest_cache/
+*.pyc

--- a/feature_engineering.py
+++ b/feature_engineering.py
@@ -1,0 +1,114 @@
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import StandardScaler
+
+
+def add_tech_indicators(df: pd.DataFrame) -> pd.DataFrame:
+    """Add technical indicators to price DataFrame.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Must contain at least the columns 'open', 'high', 'low', 'close', 'volume'.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with additional columns for each indicator.
+    """
+    df = df.copy()
+
+    # Returns
+    df["returns"] = df["close"].pct_change()
+    df["log_returns"] = np.log1p(df["returns"])
+
+    # Simple Moving Averages
+    df["SMA_7"] = df["close"].rolling(window=7).mean()
+    df["SMA_21"] = df["close"].rolling(window=21).mean()
+
+    # Exponential Moving Averages
+    df["EMA_12"] = df["close"].ewm(span=12, adjust=False).mean()
+    df["EMA_26"] = df["close"].ewm(span=26, adjust=False).mean()
+
+    # RSI
+    delta = df["close"].diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+    avg_gain = gain.rolling(window=14).mean()
+    avg_loss = loss.rolling(window=14).mean()
+    rs = avg_gain / avg_loss
+    df["RSI_14"] = 100 - (100 / (1 + rs))
+
+    # ATR
+    high_low = df["high"] - df["low"]
+    high_close = (df["high"] - df["close"].shift()).abs()
+    low_close = (df["low"] - df["close"].shift()).abs()
+    tr = pd.concat([high_low, high_close, low_close], axis=1).max(axis=1)
+    df["ATR_14"] = tr.rolling(window=14).mean()
+
+    # Bollinger Bands
+    middle = df["close"].rolling(window=20).mean()
+    std = df["close"].rolling(window=20).std()
+    df["BB_m"] = middle
+    df["BB_u"] = middle + 2 * std
+    df["BB_l"] = middle - 2 * std
+
+    # MACD
+    ema12 = df["close"].ewm(span=12, adjust=False).mean()
+    ema26 = df["close"].ewm(span=26, adjust=False).mean()
+    macd = ema12 - ema26
+    signal = macd.ewm(span=9, adjust=False).mean()
+    df["MACD"] = macd
+    df["MACD_signal"] = signal
+    df["MACD_hist"] = macd - signal
+
+    return df
+
+
+def make_supervised(
+    df: pd.DataFrame,
+    target_horizon: int = 1,
+    window: int = 30,
+    features: list | None = None,
+):
+    """Convert price data into supervised learning datasets.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Price DataFrame.
+    target_horizon : int, default 1
+        Number of steps ahead to predict.
+    window : int, default 30
+        Number of initial rows to drop to avoid look-ahead bias.
+    features : list, optional
+        Specific feature columns to use.
+
+    Returns
+    -------
+    tuple
+        (X, y, feature_names)
+    """
+    df = add_tech_indicators(df.copy())
+
+    df["target"] = (df["close"].shift(-target_horizon) > df["close"]).astype(int)
+
+    if features is None:
+        exclude = {"open", "high", "low", "close", "volume", "target"}
+        features = [c for c in df.columns if c not in exclude]
+
+    # Purge initial window and final target_horizon rows
+    df = df.iloc[window:-target_horizon].dropna()
+
+    X = df[features].to_numpy()
+    y = df["target"].to_numpy()
+
+    return X, y, features
+
+
+def scale_features(X_train, X_test):
+    """Scale features using StandardScaler fitted on X_train."""
+    scaler = StandardScaler()
+    X_train_scaled = scaler.fit_transform(X_train)
+    X_test_scaled = scaler.transform(X_test)
+    return X_train_scaled, X_test_scaled, scaler

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pandas as pd
+
+from feature_engineering import add_tech_indicators, make_supervised, scale_features
+
+
+def sample_df(n=120):
+    rng = pd.date_range("2020-01-01", periods=n, freq="D")
+    prices = np.cumsum(np.random.randn(n)) + 100
+    df = pd.DataFrame(index=rng)
+    df["open"] = prices + np.random.randn(n)
+    df["high"] = df["open"] + np.abs(np.random.randn(n))
+    df["low"] = df["open"] - np.abs(np.random.randn(n))
+    df["close"] = prices + np.random.randn(n)
+    df["volume"] = np.random.randint(100, 1000, size=n)
+    return df
+
+
+def test_make_supervised_shapes():
+    np.random.seed(42)
+    df = sample_df()
+    X, y, features = make_supervised(df, target_horizon=1, window=30)
+    assert X.shape[0] == y.shape[0]
+    assert X.shape[1] == len(features)
+
+
+def test_scale_features():
+    np.random.seed(42)
+    df = sample_df()
+    X, y, features = make_supervised(df, target_horizon=1, window=30)
+    X_train, X_test = X[:50], X[50:]
+    X_train_s, X_test_s, scaler = scale_features(X_train, X_test)
+    assert X_train_s.shape == X_train.shape
+    assert X_test_s.shape == X_test.shape
+    # mean of scaled training data is ~0
+    assert np.allclose(X_train_s.mean(axis=0), 0, atol=1e-6)


### PR DESCRIPTION
## Summary
- implement `add_tech_indicators` with returns, moving averages, RSI, ATR, Bollinger Bands and MACD
- add `make_supervised` to build purged feature/label matrices for binary targets
- provide `scale_features` helper using `StandardScaler` and accompanying tests

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897d957d8ac83289ac2d6b9c5083ad9