### PR TITLE
Add risk utilities and integrate with backtest and paper bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/backtest.py
+++ b/backtest.py
@@ -1,0 +1,39 @@
+"""Simple backtest module using risk utilities."""
+
+from typing import Iterable, Tuple
+
+from risk_utils import apply_fee, daily_kill_switch, position_sizing
+
+
+def run_backtest(returns: Iterable[float], initial_equity: float = 10000,
+                 fee_rate: float = 0.0, stop_distance_frac: float = 0.01,
+                 risk_per_trade: float = 0.005) -> Tuple[float, list]:
+    """Run a simplistic backtest over a sequence of returns.
+
+    Parameters
+    ----------
+    returns: Iterable[float]
+        Fractional price changes per trade (e.g. 0.01 for +1%).
+    initial_equity: float
+        Starting account value.
+    fee_rate: float
+        Fee rate applied to profit/loss.
+    stop_distance_frac: float
+        Stop loss distance used for position sizing.
+    risk_per_trade: float
+        Fraction of equity risked per trade.
+    """
+    equity = initial_equity
+    equity_curve = [equity]
+
+    for r in returns:
+        size = position_sizing(equity, risk_per_trade, stop_distance_frac)
+        pnl = size * r
+        pnl_after_fee = apply_fee(pnl, fee_rate)
+        equity += pnl_after_fee
+        equity_curve.append(equity)
+        if daily_kill_switch(equity_curve):
+            break
+
+    return equity, equity_curve
+

--- a/paper_bot.py
+++ b/paper_bot.py
@@ -1,0 +1,29 @@
+"""Paper trading bot utilizing risk utilities."""
+
+from typing import List
+
+from risk_utils import apply_fee, daily_kill_switch, position_sizing
+
+
+class PaperBot:
+    """A minimal paper trading bot that tracks equity and trades returns."""
+
+    def __init__(self, starting_equity: float, fee_rate: float = 0.0):
+        self.equity = starting_equity
+        self.fee_rate = fee_rate
+        self.equity_curve: List[float] = [starting_equity]
+
+    def trade(self, fractional_return: float, stop_distance_frac: float = 0.01,
+              risk_per_trade: float = 0.005) -> float:
+        """Execute a trade and update internal equity."""
+        size = position_sizing(self.equity, risk_per_trade, stop_distance_frac)
+        pnl = size * fractional_return
+        pnl_after_fee = apply_fee(pnl, self.fee_rate)
+        self.equity += pnl_after_fee
+        self.equity_curve.append(self.equity)
+        return self.equity
+
+    def should_stop_trading(self, max_dd: float = 0.02) -> bool:
+        """Return True if drawdown exceeds the limit."""
+        return daily_kill_switch(self.equity_curve, max_dd)
+

--- a/risk_utils.py
+++ b/risk_utils.py
@@ -1,0 +1,51 @@
+"""Risk management utility functions."""
+
+from typing import Sequence
+
+
+def apply_fee(amount: float, fee_rate: float) -> float:
+    """Return *amount* after deducting a fee.
+
+    Parameters
+    ----------
+    amount: float
+        Original amount in USD.
+    fee_rate: float
+        Fee rate as a fraction (e.g. 0.001 for 0.1%).
+    """
+    return amount * (1 - fee_rate)
+
+
+def position_sizing(equity: float, risk_per_trade: float = 0.005,
+                    stop_distance_frac: float = 0.01) -> float:
+    """Return target position size in USD.
+
+    The size is computed as the capital at risk divided by the
+    fractional stop distance.
+    """
+    if stop_distance_frac <= 0:
+        raise ValueError("stop_distance_frac must be positive")
+    risk_capital = equity * risk_per_trade
+    return risk_capital / stop_distance_frac
+
+
+def daily_kill_switch(equity_series: Sequence[float], max_dd: float = 0.02) -> bool:
+    """Return True if drawdown from the peak exceeds *max_dd*.
+
+    Parameters
+    ----------
+    equity_series: Sequence[float]
+        Historical equity values for the current day.
+    max_dd: float
+        Maximum allowed drawdown as a fraction.
+    """
+    if not equity_series:
+        return False
+
+    peak = equity_series[0]
+    for value in equity_series:
+        if value > peak:
+            peak = value
+    drawdown = (peak - equity_series[-1]) / peak
+    return drawdown >= max_dd
+

--- a/tests/test_risk_utils.py
+++ b/tests/test_risk_utils.py
@@ -1,0 +1,14 @@
+from risk_utils import position_sizing, daily_kill_switch, apply_fee
+
+
+def test_position_sizing_basic():
+    assert position_sizing(10000) == 10000 * 0.005 / 0.01
+
+
+def test_apply_fee():
+    assert apply_fee(100, 0.1) == 90
+
+
+def test_daily_kill_switch():
+    assert daily_kill_switch([100, 98]) is True
+    assert daily_kill_switch([100, 99]) is False


### PR DESCRIPTION
## Summary
- add position sizing, daily kill switch, and fee application helpers
- wire risk helpers into simple backtest and paper trading bot modules
- cover core risk utilities with unit tests

## Testing
- `python -m pytest -q`
- `python -m py_compile risk_utils.py backtest.py paper_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6897d99059a88328a3cf2e8f0fb3d955