### PR TITLE
Ensure tests can import project modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure project root is on PYTHONPATH for module imports
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)


### PR DESCRIPTION
## Summary
- Add test configuration to include project root on `PYTHONPATH`
- Allows feature engineering functions and other modules to be imported during tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898129dd73c8328ad7258758f3e8be4