### PR TITLE
Ensure binary predictor returns two-column probabilities

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+
+class KerasLSTMClassifier:
+    """Wrapper around a Keras model providing scikit-learn style predict_proba."""
+
+    def __init__(self, model):
+        self.model = model
+
+    def predict_proba(self, X):
+        """Return probabilities in scikit-learn's two-column format.
+
+        Many Keras binary classifiers output an array with a single column
+        representing the probability of the positive class. scikit-learn's
+        ``predict_proba`` convention, however, is to return two columns:
+        ``[P(class=0), P(class=1)]``.  This method ensures that behaviour.
+        """
+        p = self.model.predict(X)
+        p = np.asarray(p)
+
+        # If the underlying model already returns two columns we simply
+        # forward the output.
+        if p.ndim == 2 and p.shape[1] == 2:
+            return p
+
+        # For one-dimensional outputs we ensure the array is 1D
+        if p.ndim == 2 and p.shape[1] == 1:
+            p = p.ravel()
+        elif p.ndim > 2:
+            raise ValueError("Unexpected probability shape: %s" % (p.shape,))
+
+        # At this point ``p`` should be one-dimensional. Construct the
+        # negative class probability and stack the result into the expected
+        # two-column format.
+        return np.column_stack([1 - p, p])

--- a/signal_strategy.py
+++ b/signal_strategy.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+
+class SignalStrategy:
+    """Simple strategy utilities for working with prediction probabilities."""
+
+    def __init__(self, model):
+        self.model = model
+
+    def predict_proba_last(self, X):
+        """Return the probability for the positive class of the last sample.
+
+        The method is resilient to models that return either a single column
+        of positive class probabilities or the two-column scikit-learn
+        convention. In all cases the probability of the positive class for
+        the last sample is returned as a scalar.
+        """
+        proba = self.model.predict_proba(X)
+        proba = np.asarray(proba)
+
+        # Normalise single column outputs into two-column format
+        if proba.ndim == 1:
+            proba = np.column_stack([1 - proba, proba])
+        elif proba.ndim == 2 and proba.shape[1] == 1:
+            proba = np.column_stack([1 - proba[:, 0], proba[:, 0]])
+
+        return proba[-1, 1]

--- a/tests/test_predict_proba.py
+++ b/tests/test_predict_proba.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# Ensure the repository root is on the import path so ``models`` and
+# ``signal_strategy`` can be imported when the tests are executed from a
+# different working directory.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from models import KerasLSTMClassifier
+from signal_strategy import SignalStrategy
+
+
+class DummyKerasModel:
+    def predict(self, X):
+        # Return a single column of probabilities
+        return np.array([[0.2], [0.8], [0.6]])
+
+
+def test_predict_proba_two_columns():
+    clf = KerasLSTMClassifier(DummyKerasModel())
+    proba = clf.predict_proba(np.zeros((3, 2)))
+    assert proba.shape == (3, 2)
+    assert np.allclose(proba[:, 0], 1 - proba[:, 1])
+
+
+class TwoColumnModel:
+    def predict_proba(self, X):
+        return np.array([[0.4, 0.6], [0.3, 0.7]])
+
+
+class OneColumnModel:
+    def predict_proba(self, X):
+        return np.array([[0.6], [0.8]])
+
+
+def test_signal_strategy_two_columns():
+    strat = SignalStrategy(TwoColumnModel())
+    last = strat.predict_proba_last(np.zeros((2, 2)))
+    assert last == 0.7
+
+
+def test_signal_strategy_one_column():
+    strat = SignalStrategy(OneColumnModel())
+    last = strat.predict_proba_last(np.zeros((2, 2)))
+    assert last == 0.8


### PR DESCRIPTION
## Summary
- Normalize `KerasLSTMClassifier.predict_proba` to emit `[1-p, p]` like scikit-learn
- Allow `SignalStrategy.predict_proba_last` to handle single-column model outputs
- Add unit tests for probability formatting and strategy behaviour

## Testing
- `pytest tests/test_predict_proba.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689818f54c1083289c9cecfb35f3042e