### PR TITLE
Add pytest configuration for project root

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration for ensuring repository root on sys.path."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add the project root to ``sys.path`` so tests can import local packages
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_predict_proba.py
+++ b/tests/test_predict_proba.py
@@ -1,14 +1,4 @@
-import sys
-from pathlib import Path
-
 import numpy as np
-
-# Ensure the repository root is on the import path so ``models`` and
-# ``signal_strategy`` can be imported when the tests are executed from a
-# different working directory.
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
 
 from models import KerasLSTMClassifier
 from signal_strategy import SignalStrategy


### PR DESCRIPTION
## Summary
- ensure repository root is on `sys.path` for all tests via `tests/conftest.py`
- simplify `tests/test_predict_proba.py` after centralizing path setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68981a7927e883289bd245b9a88f210b