### PR TITLE
Align training and backtest artifacts

### DIFF
--- a/src/backtest/strategy.py
+++ b/src/backtest/strategy.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Literal
+
+import joblib
+import numpy as np
+import pandas as pd
+
+
+class SignalStrategy:
+    """Utility strategy used during backtesting.
+
+    The strategy expects model artefacts stored using the layout produced by
+    :func:`src.ml.train.train`::
+
+        models/{SYMBOL}/
+            model.pkl
+            model.h5       # optional, presence indicates LSTM
+            scaler.pkl
+            features.json
+            report.json
+            diagnostic.png
+
+    Parameters
+    ----------
+    symbol:
+        Trading pair or symbol identifier.
+    model_dir:
+        Root directory containing the ``models`` folder.
+    buy_thr, sell_thr, min_edge:
+        Thresholds controlling the generated signal.
+    """
+
+    def __init__(
+        self,
+        symbol: str,
+        model_dir: str = "models",
+        *,
+        buy_thr: float = 0.6,
+        sell_thr: float = 0.4,
+        min_edge: float = 0.02,
+    ) -> None:
+        self.symbol = symbol
+        self.buy_thr = buy_thr
+        self.sell_thr = sell_thr
+        self.min_edge = min_edge
+
+        base = Path(model_dir) / symbol
+        self.model = joblib.load(base / "model.pkl")
+        scaler_path = base / "scaler.pkl"
+        self.scaler = joblib.load(scaler_path) if scaler_path.exists() else None
+        with open(base / "features.json", "r", encoding="utf-8") as fh:
+            self.feature_names: List[str] = json.load(fh)
+        # Presence of model.h5 marks an LSTM model which requires special
+        # treatment of input shapes.
+        self.is_lstm = (base / "model.h5").exists()
+
+    def _predict_proba_last(self, X: np.ndarray) -> float:
+        """Return probability of the positive class for the last sample."""
+        proba = self.model.predict_proba(X)
+        proba = np.asarray(proba)
+        if proba.ndim == 1:
+            proba = np.column_stack([1 - proba, proba])
+        elif proba.ndim == 2 and proba.shape[1] == 1:
+            proba = np.column_stack([1 - proba[:, 0], proba[:, 0]])
+        return proba[-1, 1]
+
+    def generate_signal(self, df_window: pd.DataFrame) -> Literal["BUY", "SELL", "HOLD"]:
+        """Generate trading signal from a window of data."""
+        X = df_window[self.feature_names].values
+        if self.scaler is not None:
+            X = self.scaler.transform(X)
+        if self.is_lstm:
+            X = X.reshape(1, X.shape[0], X.shape[1])
+        proba = self._predict_proba_last(X)
+        if proba >= self.buy_thr and (proba - 0.5) >= self.min_edge:
+            return "BUY"
+        if proba <= self.sell_thr and (0.5 - proba) >= self.min_edge:
+            return "SELL"
+        return "HOLD"

--- a/src/ml/train.py
+++ b/src/ml/train.py
@@ -1,28 +1,95 @@
-"""Training utilities for AlkalosProject."""
+"""Training utilities for AlkalosProject.
+
+This module provides a very small stub ``train`` function that persists a
+trained model and its accompanying artefacts following the convention used by
+``SignalStrategy`` during backtesting.  The function is intentionally minimal
+but mirrors the expected directory layout so that unit tests can exercise the
+loading logic of the strategy component.
+"""
 from __future__ import annotations
 
+import json
 import os
-from typing import Any
+from pathlib import Path
+from typing import Iterable, Sequence, Any
+
 import joblib
 
 
-def train(model_dir: str, features: Any) -> None:
-    """Train a model and persist the features.
+class _IdentityScaler:
+    """Fallback scaler used for tests.
+
+    The scaler simply returns the input unchanged which is sufficient for the
+    lightweight unit tests in this kata-style repository.
+    """
+
+    def transform(self, X):  # pragma: no cover - trivial behaviour
+        return X
+
+
+def train(
+    symbol: str,
+    feature_names: Sequence[str],
+    model: Any | None = None,
+    *,
+    model_dir: str = "models",
+    scaler: Any | None = None,
+    is_lstm: bool = False,
+    report: dict | None = None,
+    diagnostic: bytes | None = None,
+) -> None:
+    """Persist a model and its artefacts following the project contract.
 
     Parameters
     ----------
+    symbol:
+        Trading symbol for which the model was trained.
+    feature_names:
+        Ordered list of feature names used during training.
+    model:
+        Trained estimator to serialise with :mod:`joblib`.  When ``None`` a
+        simple placeholder object is stored.
     model_dir:
-        Directory where the model and features will be stored.
-    features:
-        The feature data used for training.
+        Root directory under which the symbol folder will be created.
+    scaler:
+        Optional pre-processing scaler.  When omitted an identity scaler is
+        stored so that downstream code can unconditionally apply
+        ``scaler.transform``.
+    is_lstm:
+        If ``True`` an empty ``model.h5`` file is created to mimic the
+        presence of an LSTM model.
+    report:
+        Arbitrary metadata to be written to ``report.json``.
+    diagnostic:
+        Optional binary content for ``diagnostic.png``.
     """
-    os.makedirs(model_dir, exist_ok=True)
-    # Placeholder model; in a real project this would be a trained estimator.
-    model = {"weights": [0.1, 0.2, 0.3]}
-    joblib.dump(model, os.path.join(model_dir, "model.pkl"))
-    # Persist features with joblib for fast loading.
-    joblib.dump(features, os.path.join(model_dir, "features.pkl"))
+
+    artefact_dir = Path(model_dir) / symbol
+    artefact_dir.mkdir(parents=True, exist_ok=True)
+
+    if model is None:
+        model = {"weights": [0.1, 0.2, 0.3]}
+    joblib.dump(model, artefact_dir / "model.pkl")
+
+    if is_lstm:
+        # The actual LSTM weights would live in this file.  For test purposes we
+        # merely create an empty placeholder so that the strategy can detect the
+        # model type.
+        (artefact_dir / "model.h5").write_bytes(b"")
+
+    if scaler is None:
+        scaler = _IdentityScaler()
+    joblib.dump(scaler, artefact_dir / "scaler.pkl")
+
+    with open(artefact_dir / "features.json", "w", encoding="utf-8") as fh:
+        json.dump(list(feature_names), fh)
+
+    with open(artefact_dir / "report.json", "w", encoding="utf-8") as fh:
+        json.dump(report or {}, fh)
+
+    with open(artefact_dir / "diagnostic.png", "wb") as fh:
+        fh.write(diagnostic or b"")
 
 
-if __name__ == "__main__":
-    train("model", [1, 2, 3])
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    train("EXAMPLE", ["feat1", "feat2"])  # type: ignore[arg-type]

--- a/tests/test_signal_strategy.py
+++ b/tests/test_signal_strategy.py
@@ -1,9 +1,44 @@
+import numpy as np
+import pandas as pd
+
 from src.ml.train import train
-from src.strategies.signal_strategy import SignalStrategy
+from src.backtest.strategy import SignalStrategy
 
 
-def test_signal_strategy_loads_features(tmp_path):
-    model_dir = tmp_path / "model"
-    train(str(model_dir), [1, 2, 3])
-    strategy = SignalStrategy(str(model_dir))
-    assert strategy.features == [1, 2, 3]
+class DummyModel:
+    def predict_proba(self, X):
+        # Return constant probability favouring the positive class.
+        return np.array([[0.3, 0.7] for _ in range(len(X))])
+
+
+class LSTMModel(DummyModel):
+    def __init__(self):
+        self.last_shape = None
+
+    def predict_proba(self, X):  # pragma: no cover - simple wrapper
+        self.last_shape = X.shape
+        return super().predict_proba(X)
+
+
+def test_signal_strategy_loads_features_and_generates_signal(tmp_path):
+    model_root = tmp_path / "models"
+    train("SYMBOL", ["a", "b"], model=DummyModel(), model_dir=str(model_root))
+    strat = SignalStrategy("SYMBOL", model_dir=str(model_root))
+    assert strat.feature_names == ["a", "b"]
+    df = pd.DataFrame({"a": [0], "b": [0]})
+    assert strat.generate_signal(df) == "BUY"
+
+
+def test_lstm_window_reshaping(tmp_path):
+    model_root = tmp_path / "models"
+    train(
+        "LSTM",
+        ["x"],
+        model=LSTMModel(),
+        model_dir=str(model_root),
+        is_lstm=True,
+    )
+    strat = SignalStrategy("LSTM", model_dir=str(model_root))
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    strat.generate_signal(df)
+    assert strat.model.last_shape == (1, 3, 1)


### PR DESCRIPTION
## Summary
- Expand `train` to save all expected model artifacts under `models/{SYMBOL}/`
- Introduce backtest `SignalStrategy` that loads artifacts, handles LSTM reshaping and threshold-based signals
- Add tests covering artifact loading and LSTM reshaping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68981e2c5dc0832887c17826427ec1a0