### PR TITLE
Add Pydantic settings loader and .env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DATA_DIR=./data
+MODELS_DIR=./models
+LOGS_DIR=./logs
+SYMBOLS=BTC,ETH
+FIAT=USD

--- a/configs/settings.py
+++ b/configs/settings.py
@@ -1,0 +1,31 @@
+from functools import lru_cache
+from pathlib import Path
+from typing import List
+
+from pydantic import field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    data_dir: Path = Path("./data")
+    models_dir: Path = Path("./models")
+    logs_dir: Path = Path("./logs")
+    symbols: List[str] = ["BTC", "ETH"]
+    fiat: str = "USD"
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+    @field_validator("data_dir", "models_dir", "logs_dir", mode="before")
+    @classmethod
+    def create_dir(cls, v: str) -> Path:
+        path = Path(v)
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    return Settings()
+
+
+settings = get_settings()


### PR DESCRIPTION
## Summary
- add `.env.example` with directories, symbols, and fiat variables
- create `configs/settings.py` using Pydantic to load env vars, ensure directories exist, and expose cached `get_settings`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68981e34643483288a5ff84ab233e6bc