### PR TITLE
Implement CLI and utilities for market data fetching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 numpy
 joblib
+pandas
+requests
+yfinance

--- a/src/backtest/strategy.py
+++ b/src/backtest/strategy.py
@@ -13,50 +13,43 @@ import pandas as pd
 class SignalStrategy:
     """Utility strategy used during backtesting.
 
-    The strategy expects model artefacts stored using the layout produced by
-    :func:`src.ml.train.train`::
-
-        models/{SYMBOL}/
-            model.pkl
-            model.h5       # optional, presence indicates LSTM
-            scaler.pkl
-            features.json
-            report.json
-            diagnostic.png
-
-    Parameters
-    ----------
-    symbol:
-        Trading pair or symbol identifier.
-    model_dir:
-        Root directory containing the ``models`` folder.
-    buy_thr, sell_thr, min_edge:
-        Thresholds controlling the generated signal.
+    The class normally expects a ``symbol`` string and loads the
+    corresponding model artefacts from ``model_dir``.  For testing purposes
+    a model instance can be supplied directly as the first argument.
     """
 
     def __init__(
         self,
-        symbol: str,
+        symbol_or_model,
         model_dir: str = "models",
         *,
         buy_thr: float = 0.6,
         sell_thr: float = 0.4,
         min_edge: float = 0.02,
     ) -> None:
-        self.symbol = symbol
         self.buy_thr = buy_thr
         self.sell_thr = sell_thr
         self.min_edge = min_edge
 
-        base = Path(model_dir) / symbol
-        self.model = joblib.load(base / "model.pkl")
-        scaler_path = base / "scaler.pkl"
-        self.scaler = joblib.load(scaler_path) if scaler_path.exists() else None
-        with open(base / "features.json", "r", encoding="utf-8") as fh:
-            self.feature_names: List[str] = json.load(fh)
-        # Presence of model.h5 marks an LSTM model which requires special
-        # treatment of input shapes.
-        self.is_lstm = (base / "model.h5").exists()
+        if isinstance(symbol_or_model, str):
+            symbol = symbol_or_model
+            self.symbol = symbol
+            base = Path(model_dir) / symbol
+            self.model = joblib.load(base / "model.pkl")
+            scaler_path = base / "scaler.pkl"
+            self.scaler = joblib.load(scaler_path) if scaler_path.exists() else None
+            with open(base / "features.json", "r", encoding="utf-8") as fh:
+                self.feature_names: List[str] = json.load(fh)
+            # Presence of model.h5 marks an LSTM model which requires special
+            # treatment of input shapes.
+            self.is_lstm = (base / "model.h5").exists()
+        else:
+            # Direct model instance supplied (used in unit tests)
+            self.symbol = ""
+            self.model = symbol_or_model
+            self.scaler = None
+            self.feature_names = []
+            self.is_lstm = False
 
     def _predict_proba_last(self, X: np.ndarray) -> float:
         """Return probability of the positive class for the last sample."""
@@ -67,6 +60,10 @@ class SignalStrategy:
         elif proba.ndim == 2 and proba.shape[1] == 1:
             proba = np.column_stack([1 - proba[:, 0], proba[:, 0]])
         return proba[-1, 1]
+
+    # Public wrapper used in tests
+    def predict_proba_last(self, X: np.ndarray) -> float:  # pragma: no cover - thin wrapper
+        return self._predict_proba_last(X)
 
 
     def generate_signal(self, df_window: pd.DataFrame) -> Literal["BUY", "SELL", "HOLD"]:

--- a/src/data_fetch.py
+++ b/src/data_fetch.py
@@ -1,4 +1,113 @@
-"""Utilities for downloading and caching raw market data."""
+"""Command line utility for downloading OHLCV market data.
 
-# TODO: Implement data retrieval logic
+The script provides a small CLI that can pull daily OHLCV candles from
+either the public CoinGecko API or Yahoo! Finance via :mod:`yfinance`.
+Downloaded data are normalised and written to CSV files following the
+pattern ``data/{symbol}_{fiat}_1d.csv``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import time
+from pathlib import Path
+from typing import Callable, Dict, List
+
+import pandas as pd
+
+from utils.market_data import fetch_coingecko_ohlc, fetch_yf_ohlc
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fetch OHLCV market data")
+    parser.add_argument(
+        "--source",
+        choices=["coingecko", "yf"],
+        required=True,
+        help="Data provider to use",
+    )
+    parser.add_argument(
+        "--symbols",
+        default="BTC,ETH",
+        help="Comma separated list of symbols to download",
+    )
+    parser.add_argument(
+        "--fiat",
+        default="USD",
+        help="Fiat currency to quote against",
+    )
+    parser.add_argument(
+        "--days",
+        default="max",
+        help="Number of days to pull (""yfinance"" period argument)",
+    )
+    parser.add_argument(
+        "--outfile",
+        default="data/{symbol}_{fiat}_1d.csv",
+        help="Output file pattern",
+    )
+    return parser.parse_args()
+
+
+def _ensure_dirs(path: str) -> None:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+
+
+def _fetch_with_retry(func: Callable[..., pd.DataFrame], *args, **kwargs) -> pd.DataFrame:
+    """Execute ``func`` honouring a basic rate limit and exponential backoff."""
+
+    rate_limit = 1.0  # seconds between requests
+    retries = 5
+    for attempt in range(retries):
+        if attempt:
+            wait = 2**attempt
+            logging.warning("Retrying after %.1f s", wait)
+            time.sleep(wait)
+        time.sleep(rate_limit)
+        try:
+            return func(*args, **kwargs)
+        except Exception as exc:  # pragma: no cover - best effort logging
+            logging.warning("Fetch failed (%s)", exc)
+    raise RuntimeError("Maximum retries exceeded")
+
+
+def main() -> None:
+    args = _parse_args()
+
+    _ensure_dirs("logs/data_fetch.log")
+    logging.basicConfig(
+        filename="logs/data_fetch.log",
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    symbols: List[str] = [s.strip().upper() for s in args.symbols.split(",") if s.strip()]
+    fetchers: Dict[str, Callable[[str, str, str], pd.DataFrame]] = {
+        "coingecko": lambda sym, fiat, days: fetch_coingecko_ohlc(sym, vs_currency=fiat, days=days),
+        "yf": lambda sym, fiat, days: fetch_yf_ohlc(sym, vs_currency=fiat, days=days),
+    }
+    fetch = fetchers[args.source]
+
+    for symbol in symbols:
+        logging.info("Fetching %s from %s", symbol, args.source)
+        try:
+            df = _fetch_with_retry(fetch, symbol, args.fiat, args.days)
+        except Exception as exc:  # pragma: no cover - best effort logging
+            logging.error("Failed to fetch %s: %s", symbol, exc)
+            continue
+
+        # Ensure expected schema
+        df = df[~df.index.duplicated(keep="first")].sort_index()
+        df.index = pd.to_datetime(df["timestamp"], unit="ms", utc=True)
+        df = df[["timestamp", "open", "high", "low", "close", "volume"]]
+
+        outfile = args.outfile.format(symbol=symbol, fiat=args.fiat.upper())
+        _ensure_dirs(outfile)
+        df.to_csv(outfile)
+        logging.info("Saved %s rows to %s", len(df), outfile)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
 

--- a/src/utils/market_data.py
+++ b/src/utils/market_data.py
@@ -1,4 +1,166 @@
-"""Helpers for working with market data sources."""
+"""Helpers for working with market data sources.
 
-# TODO: Implement market data utilities
+This module exposes thin wrappers around external data providers that
+return OHLCV data in a consistent :class:`pandas.DataFrame` format.  Both
+helpers share a small request utility that implements basic rate limiting
+and exponential backoff to play nicely with public APIs.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Dict, Optional
+
+import pandas as pd
+import requests
+
+# ---------------------------------------------------------------------------
+# Internal request helper
+
+
+def _request_with_retry(
+    url: str,
+    *,
+    retries: int = 5,
+    backoff: float = 1.0,
+    rate_limit: float = 1.0,
+    session: Optional[requests.Session] = None,
+):
+    """Retrieve ``url`` handling rate limiting and exponential backoff.
+
+    Parameters
+    ----------
+    url:
+        Target URL to download.
+    retries:
+        Number of attempts before giving up.
+    backoff:
+        Base backoff delay in seconds.  The actual delay grows
+        exponentially (``backoff * 2**attempt``).
+    rate_limit:
+        Minimum number of seconds between consecutive requests.
+    session:
+        Optional :class:`requests.Session` to reuse TCP connections.
+
+    Returns
+    -------
+    requests.Response
+        Successful HTTP response.
+    """
+
+    session = session or requests.Session()
+    for attempt in range(retries):
+        if _request_with_retry._last_call is not None:
+            delta = time.time() - _request_with_retry._last_call
+            if delta < rate_limit:
+                time.sleep(rate_limit - delta)
+        try:
+            response = session.get(url, timeout=30)
+            _request_with_retry._last_call = time.time()
+            response.raise_for_status()
+            return response
+        except Exception as exc:  # pragma: no cover - best effort logging
+            wait = backoff * (2**attempt)
+            logging.warning("Request failed (%s). Retrying in %.1f s", exc, wait)
+            time.sleep(wait)
+    raise RuntimeError(f"Failed to fetch {url}")
+
+
+_request_with_retry._last_call = None  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Public fetch helpers
+
+COINGECKO_IDS: Dict[str, str] = {
+    "BTC": "bitcoin",
+    "ETH": "ethereum",
+}
+
+
+def fetch_coingecko_ohlc(
+    symbol: str,
+    *,
+    vs_currency: str = "usd",
+    days: str = "max",
+) -> pd.DataFrame:
+    """Fetch OHLCV data from the public CoinGecko API.
+
+    The returned :class:`~pandas.DataFrame` is indexed by UTC datetimes and
+    contains the columns ``timestamp``, ``open``, ``high``, ``low``,
+    ``close`` and ``volume``.
+    """
+
+    coin_id = COINGECKO_IDS.get(symbol.upper())
+    if not coin_id:
+        raise ValueError(f"Unsupported symbol {symbol}")
+
+    url = (
+        "https://api.coingecko.com/api/v3/coins/"
+        f"{coin_id}/market_chart?vs_currency={vs_currency.lower()}&days={days}&interval=daily"
+    )
+
+    response = _request_with_retry(url)
+    data = response.json()
+
+    prices = data.get("prices", [])
+    volumes = data.get("total_volumes", [])
+    if not prices:
+        return pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
+
+    df_p = pd.DataFrame(prices, columns=["timestamp", "price"])
+    df_v = pd.DataFrame(volumes, columns=["timestamp", "volume"])
+    df = pd.merge(df_p, df_v, on="timestamp", how="left")
+
+    df["date"] = pd.to_datetime(df["timestamp"], unit="ms", utc=True).dt.floor("D")
+    price_grp = df.groupby("date")["price"]
+    vol_grp = df.groupby("date")["volume"]
+    ohlc = price_grp.agg(open="first", high="max", low="min", close="last")
+    vol = vol_grp.sum()
+    out = pd.concat([ohlc, vol], axis=1)
+    out.index.name = None
+    out["timestamp"] = (out.index.view("int64") // 10**6)
+    out = out[["timestamp", "open", "high", "low", "close", "volume"]]
+    out = out[~out.index.duplicated(keep="first")].sort_index()
+    return out
+
+
+def fetch_yf_ohlc(
+    symbol: str,
+    *,
+    vs_currency: str = "USD",
+    days: str = "max",
+) -> pd.DataFrame:
+    """Fetch OHLCV data using :mod:`yfinance`.
+
+    Parameters mirror :func:`fetch_coingecko_ohlc` and the returned DataFrame
+    follows the same schema.
+    """
+
+    import yfinance as yf
+
+    ticker = f"{symbol.upper()}-{vs_currency.upper()}"
+    df = yf.download(ticker, period=days, interval="1d", progress=False, auto_adjust=False)
+    if df.empty:
+        return pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
+
+    df = df.rename(
+        columns={
+            "Open": "open",
+            "High": "high",
+            "Low": "low",
+            "Close": "close",
+            "Volume": "volume",
+        }
+    )
+    df.index = df.index.tz_localize("UTC") if df.index.tz is None else df.index.tz_convert("UTC")
+    df["timestamp"] = (df.index.view("int64") // 10**6)
+    df = df[["timestamp", "open", "high", "low", "close", "volume"]]
+    df = df[~df.index.duplicated(keep="first")].sort_index()
+    return df
+
+
+__all__ = ["fetch_coingecko_ohlc", "fetch_yf_ohlc"]
+
 


### PR DESCRIPTION
## Summary
- add `data_fetch` CLI supporting CoinGecko and Yahoo! Finance sources with logging, retries and rate limiting
- implement OHLCV helpers for CoinGecko and yfinance
- allow `SignalStrategy` to take model instances directly for tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898203cf97483289cb2667939f6c8d8