### PR TITLE
Add utilities and tests for dataset splitting, accounting and hysteresis

### DIFF
--- a/src/backtest/engine.py
+++ b/src/backtest/engine.py
@@ -1,4 +1,69 @@
-"""Backtest engine placeholder."""
+"""Minimal backtesting engine used in unit tests."""
 
-# TODO: Implement backtesting engine
+from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import pandas as pd
+
+
+@dataclass
+class Trade:
+    """Simple trade record."""
+
+    timestamp: object
+    type: str
+    price: float
+    qty: float
+
+
+TradeList = List[Trade]
+
+
+def backtest_spot(
+    df: pd.DataFrame,
+    *,
+    fee: float = 0.0,
+    slippage: float = 0.0,  # pragma: no cover - reserved for future use
+    initial_cash: float = 1000.0,
+) -> Tuple[dict, pd.Series, pd.DataFrame]:
+    """Run a tiny spot backtest driven by ``signal`` column.
+
+    Parameters
+    ----------
+    df:
+        ``DataFrame`` containing at least ``close`` and ``signal`` columns.
+    fee:
+        Proportional trading fee applied on both entry and exit.
+    slippage:
+        Currently unused but kept for API compatibility.
+    initial_cash:
+        Starting cash for the backtest.
+    """
+
+    cash = initial_cash
+    position = 0.0
+    equity_curve = []
+    trades: TradeList = []
+
+    for ts, row in df.iterrows():
+        price = float(row["close"])
+        signal = row.get("signal", "HOLD")
+
+        if signal == "BUY" and cash >= price * (1 + fee):
+            qty = 1.0
+            cash -= price * (1 + fee)
+            position += qty
+            trades.append(Trade(ts, "BUY", price, qty))
+        elif signal == "SELL" and position >= 1.0:
+            cash += price * (1 - fee) * 1.0
+            trades.append(Trade(ts, "SELL", price, 1.0))
+            position -= 1.0
+
+        equity_curve.append(cash + position * price)
+
+    summary = {"final_equity": equity_curve[-1] if equity_curve else initial_cash}
+    equity = pd.Series(equity_curve, index=df.index, name="equity")
+    trades_df = pd.DataFrame(trades)
+    return summary, equity, trades_df

--- a/src/ml/data_utils.py
+++ b/src/ml/data_utils.py
@@ -1,4 +1,62 @@
-"""Dataset manipulation helpers."""
+"""Dataset manipulation helpers.
 
-# TODO: Implement dataset utilities
+This module contains a couple of tiny helpers used in the unit tests.  The
+functions intentionally keep the implementation compact while providing a
+realistic interface for working with time series data.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+from typing import Tuple
+
+
+def make_lagged_features(series: pd.Series, window: int) -> Tuple[pd.DataFrame, pd.Series]:
+    """Create lagged features for a univariate series.
+
+    Parameters
+    ----------
+    series:
+        Input time series.
+    window:
+        Number of past observations to include as features.
+
+    Returns
+    -------
+    X, y:
+        Feature ``DataFrame`` where each column represents a lagged value and
+        the corresponding target ``Series`` aligned such that ``y_t`` depends
+        only on values strictly prior to ``t``.
+    """
+
+    data = {f"lag_{i}": series.shift(i) for i in range(1, window + 1)}
+    X = pd.DataFrame(data)
+    y = series.copy()
+    df = pd.concat([X, y], axis=1).dropna()
+    X = df[[f"lag_{i}" for i in range(1, window + 1)]]
+    y = df[series.name]
+    return X, y
+
+
+def temporal_train_test_split(
+    X: pd.DataFrame,
+    y: pd.Series,
+    *,
+    test_size: float = 0.2,
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.Series, pd.Series]:
+    """Split ``X`` and ``y`` preserving temporal order.
+
+    Unlike :func:`sklearn.model_selection.train_test_split` this helper never
+    shuffles the data which is essential when working with time series where
+    chronological ordering matters.
+    """
+
+    n_samples = len(X)
+    split = int(n_samples * (1 - test_size))
+    X_train = X.iloc[:split].copy()
+    X_test = X.iloc[split:].copy()
+    y_train = y.iloc[:split].copy()
+    y_test = y.iloc[split:].copy()
+    return X_train, X_test, y_train, y_test
+
 

--- a/tests/test_dataset_no_lookahead.py
+++ b/tests/test_dataset_no_lookahead.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+from src.ml.data_utils import make_lagged_features, temporal_train_test_split
+
+
+def test_temporal_split_and_no_lookahead():
+    series = pd.Series(range(10), name="price")
+    X, y = make_lagged_features(series, window=3)
+
+    # First row should contain only past information
+    assert X.iloc[0].tolist() == [2, 1, 0]
+    assert y.iloc[0] == 3
+
+    # The label must be greater than any feature for this monotonic series
+    assert (X.max(axis=1) < y).all()
+
+    X_train, X_test, y_train, y_test = temporal_train_test_split(X, y, test_size=0.3)
+
+    # Ensure chronological split without shuffling
+    assert X_train.index.max() < X_test.index.min()
+    assert y_train.index.max() < y_test.index.min()

--- a/tests/test_engine_accounting.py
+++ b/tests/test_engine_accounting.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import pytest
+
+from src.backtest import engine
+
+
+def test_no_signal_has_constant_equity_and_no_trades():
+    df = pd.DataFrame({
+        "close": [10, 11, 12],
+        "signal": ["HOLD", "HOLD", "HOLD"],
+    })
+    summary, equity, trades = engine.backtest_spot(df, fee=0.01, initial_cash=100)
+    assert trades.empty
+    assert (equity == 100).all()
+    assert summary["final_equity"] == 100
+
+
+def test_buy_then_sell_with_fee():
+    df = pd.DataFrame({
+        "close": [10, 12],
+        "signal": ["BUY", "SELL"],
+    })
+    summary, equity, trades = engine.backtest_spot(df, fee=0.01, initial_cash=1000)
+    # Two trades: buy and sell
+    assert len(trades) == 2
+    # Expected PnL accounting for fees
+    expected_final = 1000 - 10 * (1 + 0.01) + 12 * (1 - 0.01)
+    assert summary["final_equity"] == pytest.approx(expected_final)

--- a/tests/test_strategy_hysteresis.py
+++ b/tests/test_strategy_hysteresis.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pandas as pd
+
+from src.backtest.strategy import SignalStrategy
+
+
+class SeqModel:
+    def __init__(self, probs):
+        self.probs = list(probs)
+
+    def predict_proba(self, X):
+        p = self.probs.pop(0)
+        return np.array([[1 - p, p] for _ in range(len(X))])
+
+
+def test_hysteresis_prevents_flip_flop():
+    model = SeqModel([0.61, 0.59, 0.41, 0.39])
+    strat = SignalStrategy(model, buy_thr=0.6, sell_thr=0.4)
+    df = pd.DataFrame({"f": [0]})
+    assert strat.generate_signal(df) == "BUY"
+    assert strat.generate_signal(df) == "HOLD"
+    assert strat.generate_signal(df) == "HOLD"
+    assert strat.generate_signal(df) == "SELL"


### PR DESCRIPTION
## Summary
- implement minimal time-series dataset helpers and backtesting engine
- test dataset splitting for no lookahead
- test backtest accounting and strategy hysteresis with synthetic data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898256f88ac8328b1904d7f8ed63ee8