### PR TITLE
docs: mark unused ML utilities as experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ un modelo y generación de señales para backtesting y paper trading.
   `sell_thr` y `min_edge` al instanciar `SignalStrategy` en
   `src/live/paper_bot.py`.
 
+## Módulos experimentales
+
+Las utilidades `src/ml/feature_engineering.py` y `src/ml/data_utils.py`
+se mantienen para exploraciones fuera del flujo principal de entrenamiento y
+pueden cambiar sin previo aviso.
+
 ## Descargo de responsabilidad
 
 Este código se proporciona solo con fines educativos. No constituye asesoría

--- a/src/ml/models_wrappers.py
+++ b/src/ml/models_wrappers.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+# Usado por tests/test_predict_proba.py
 
 class KerasLSTMClassifier:
     """Wrapper around a Keras model providing scikit-learn style predict_proba."""


### PR DESCRIPTION
## Summary
- document `src/ml/feature_engineering.py` and `src/ml/data_utils.py` as experimental utilities
- annotate `KerasLSTMClassifier` wrapper with its test usage

## Testing
- `pytest -q`
- `python -m py_compile src/ml/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6898298991588328874f05bef7ce5d22