### PR TITLE
Refactor imports to new module locations

### DIFF
--- a/src/backtest/run_backtest.py
+++ b/src/backtest/run_backtest.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pandas as pd
 
 from .strategy import SignalStrategy
-from . import engine
+from src.backtest.engine import backtest_spot
 
 
 logger = logging.getLogger(__name__)
@@ -73,7 +73,7 @@ def main() -> None:
     df["signal"] = signals
 
     try:
-        summary, equity, trades = engine.backtest_spot(
+        summary, equity, trades = backtest_spot(
             df,
             fee=args.fee,
             slippage=args.slippage,

--- a/tests/test_engine_accounting.py
+++ b/tests/test_engine_accounting.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from src.backtest import engine
+from src.backtest.engine import backtest_spot
 
 
 def test_no_signal_has_constant_equity_and_no_trades():
@@ -9,7 +9,7 @@ def test_no_signal_has_constant_equity_and_no_trades():
         "close": [10, 11, 12],
         "signal": ["HOLD", "HOLD", "HOLD"],
     })
-    summary, equity, trades = engine.backtest_spot(df, fee=0.01, initial_cash=100)
+    summary, equity, trades = backtest_spot(df, fee=0.01, initial_cash=100)
     assert trades.empty
     assert (equity == 100).all()
     assert summary["final_equity"] == 100
@@ -20,7 +20,7 @@ def test_buy_then_sell_with_fee():
         "close": [10, 12],
         "signal": ["BUY", "SELL"],
     })
-    summary, equity, trades = engine.backtest_spot(df, fee=0.01, initial_cash=1000)
+    summary, equity, trades = backtest_spot(df, fee=0.01, initial_cash=1000)
     # Two trades: buy and sell
     assert len(trades) == 2
     # Expected PnL accounting for fees


### PR DESCRIPTION
## Summary
- Align imports with new package structure for backtesting engine
- Add missing package initializer for tests directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898297d25b8832896ba70e548170ea5