### PR TITLE
Centralize configuration via environment helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 DATA_DIR=./data
 MODELS_DIR=./models
 LOGS_DIR=./logs
+REPORTS_DIR=./reports
 SYMBOLS=BTC,ETH
 FIAT=USD

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ joblib
 pandas
 requests
 yfinance
+python-dotenv

--- a/src/backtest/run_backtest.py
+++ b/src/backtest/run_backtest.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from .strategy import SignalStrategy
 from src.backtest.engine import backtest_spot
+from src.utils.env import get_logs_dir, get_models_dir, get_reports_dir
 
 
 logger = logging.getLogger(__name__)
@@ -32,9 +33,9 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
 
-    _ensure_dirs("logs/run_backtest.log")
+    _ensure_dirs(str(get_logs_dir() / "run_backtest.log"))
     logging.basicConfig(
-        filename="logs/run_backtest.log",
+        filename=str(get_logs_dir() / "run_backtest.log"),
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
@@ -52,7 +53,7 @@ def main() -> None:
     try:
         strategy = SignalStrategy(
             args.symbol,
-            model_dir="models",
+            model_dir=str(get_models_dir()),
             buy_thr=args.buy_thr,
             sell_thr=args.sell_thr,
             min_edge=args.min_edge,
@@ -83,7 +84,7 @@ def main() -> None:
         logger.exception("Backtest failed: %s", exc)
         return
 
-    reports_dir = Path("reports")
+    reports_dir = get_reports_dir()
     reports_dir.mkdir(exist_ok=True)
 
     summary_path = reports_dir / f"{args.symbol}_summary.json"

--- a/src/backtest/strategy.py
+++ b/src/backtest/strategy.py
@@ -10,6 +10,8 @@ import joblib
 import numpy as np
 import pandas as pd
 
+from src.utils.env import get_models_dir
+
 
 class SignalStrategy:
     """Utility strategy used during backtesting.
@@ -23,7 +25,7 @@ class SignalStrategy:
         self,
 
         symbol_or_model,
-        model_dir: str = "models",
+        model_dir: str = str(get_models_dir()),
         *,
         buy_thr: float = 0.6,
         sell_thr: float = 0.4,

--- a/src/data_fetch.py
+++ b/src/data_fetch.py
@@ -16,7 +16,8 @@ from typing import Callable, Dict, List
 
 import pandas as pd
 
-from utils.market_data import fetch_coingecko_ohlc, fetch_yf_ohlc
+from src.utils.env import get_data_dir, get_logs_dir
+from src.utils.market_data import fetch_coingecko_ohlc, fetch_yf_ohlc
 
 
 logger = logging.getLogger(__name__)
@@ -47,7 +48,7 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--outfile",
-        default="data/{symbol}_{fiat}_1d.csv",
+        default=str(get_data_dir() / "{symbol}_{fiat}_1d.csv"),
         help="Output file pattern",
     )
     return parser.parse_args()
@@ -78,9 +79,9 @@ def _fetch_with_retry(func: Callable[..., pd.DataFrame], *args, **kwargs) -> pd.
 def main() -> None:
     args = _parse_args()
 
-    _ensure_dirs("logs/data_fetch.log")
+    _ensure_dirs(str(get_logs_dir() / "data_fetch.log"))
     logging.basicConfig(
-        filename="logs/data_fetch.log",
+        filename=str(get_logs_dir() / "data_fetch.log"),
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )

--- a/src/live/paper_bot.py
+++ b/src/live/paper_bot.py
@@ -17,6 +17,7 @@ from typing import Tuple
 import pandas as pd
 
 from src.backtest.strategy import SignalStrategy
+from src.utils.env import get_logs_dir, get_reports_dir
 
 FEE_RATE = 0.006
 SLIPPAGE = 0.0005
@@ -57,9 +58,9 @@ def _read_window(path: str, window: int) -> Tuple[pd.DataFrame, pd.Series]:
 def main() -> None:  # pragma: no cover - CLI entry point
     args = _parse_args()
 
-    _ensure_dirs("logs/paper_bot.log")
+    _ensure_dirs(str(get_logs_dir() / "paper_bot.log"))
     logging.basicConfig(
-        filename="logs/paper_bot.log",
+        filename=str(get_logs_dir() / "paper_bot.log"),
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
@@ -74,7 +75,7 @@ def main() -> None:  # pragma: no cover - CLI entry point
     asset_qty = 0.0
     equity = cash
 
-    report_path = Path("reports") / f"paper_bot_{args.symbol}.csv"
+    report_path = get_reports_dir() / f"paper_bot_{args.symbol}.csv"
     _ensure_dirs(str(report_path))
     write_header = not report_path.exists()
 

--- a/src/ml/train.py
+++ b/src/ml/train.py
@@ -18,6 +18,8 @@ import importlib
 import joblib
 import logging
 
+from src.utils.env import get_logs_dir, get_models_dir
+
 
 logger = logging.getLogger(__name__)
 
@@ -26,9 +28,9 @@ def _ensure_dirs(path: str) -> None:
     Path(path).parent.mkdir(parents=True, exist_ok=True)
 
 
-_ensure_dirs("logs/train.log")
+_ensure_dirs(str(get_logs_dir() / "train.log"))
 logging.basicConfig(
-    filename="logs/train.log",
+    filename=str(get_logs_dir() / "train.log"),
     level=logging.INFO,
     format="%(asctime)s %(levelname)s %(name)s: %(message)s",
 )
@@ -50,7 +52,7 @@ def train(
     feature_names: Sequence[str],
     model: Any | None = None,
     *,
-    model_dir: str = "models",
+    model_dir: str = str(get_models_dir()),
     scaler: Any | None = None,
     is_lstm: bool = False,
     report: dict | None = None,
@@ -134,7 +136,7 @@ def train_evaluate(
     model_type: str,
     horizon: int,
     window: int,
-    outdir: str = "models",
+    outdir: str = str(get_models_dir()),
 ) -> None:
     """Train a trivial model and persist artefacts.
 

--- a/src/ml/train_cli.py
+++ b/src/ml/train_cli.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 
+from src.utils.env import get_data_dir, get_models_dir
 from .train import train_evaluate
 
 
@@ -25,7 +26,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--csv",
-        default="data/BTC_USD_1d.csv",
+        default=str(get_data_dir() / "BTC_USD_1d.csv"),
         help="Path to CSV file containing the dataset",
     )
     parser.add_argument(
@@ -47,7 +48,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--outdir",
-        default="models",
+        default=str(get_models_dir()),
         help="Directory where artefacts will be stored",
     )
     return parser

--- a/src/utils/env.py
+++ b/src/utils/env.py
@@ -1,4 +1,82 @@
-"""Environment helpers for configuration and credentials."""
+"""Environment helpers for configuration and credentials.
 
-# TODO: Add environment handling utilities
+This module centralises access to project directories by reading optional
+settings from a ``.env`` file.  If the environment variables are missing,
+sensible defaults relative to the repository root are used.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+# Resolve repository root (``src/utils`` -> repo root)
+BASE_DIR = Path(__file__).resolve().parents[2]
+
+# Load environment variables from ``.env`` if present
+load_dotenv(BASE_DIR / ".env")
+
+
+def _resolve_dir(var_name: str, default: str) -> Path:
+    """Return a directory path from an environment variable.
+
+    Parameters
+    ----------
+    var_name:
+        Name of the environment variable to look up.
+    default:
+        Fallback relative path when the variable is undefined.
+
+    Returns
+    -------
+    pathlib.Path
+        Absolute path to the requested directory.
+    """
+
+    value = os.getenv(var_name, default)
+    path = Path(value)
+    if not path.is_absolute():
+        path = BASE_DIR / path
+    return path
+
+
+@lru_cache()
+def get_data_dir() -> Path:
+    """Return the directory where datasets are stored."""
+
+    return _resolve_dir("DATA_DIR", "data")
+
+
+@lru_cache()
+def get_models_dir() -> Path:
+    """Return the directory containing trained models."""
+
+    return _resolve_dir("MODELS_DIR", "models")
+
+
+@lru_cache()
+def get_logs_dir() -> Path:
+    """Return the directory for log files."""
+
+    return _resolve_dir("LOGS_DIR", "logs")
+
+
+@lru_cache()
+def get_reports_dir() -> Path:
+    """Return the directory for generated reports."""
+
+    return _resolve_dir("REPORTS_DIR", "reports")
+
+
+__all__ = [
+    "get_data_dir",
+    "get_models_dir",
+    "get_logs_dir",
+    "get_reports_dir",
+]
+
 


### PR DESCRIPTION
## Summary
- add `src/utils/env.py` to load `.env` and expose directory helpers
- refactor data fetch, training, backtest and live modules to use env-based paths
- document directory vars in `.env.example` and add `python-dotenv` dependency

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68982d2362408328bce83b7ba360c2ed