### PR TITLE
refactor: update ps1 scripts for new pipeline

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -3,17 +3,19 @@ param(
 )
 
 if (-not $task) {
-    Write-Host "Uso: .\make.ps1 <setup|fetch|train|bt|paper|test>" -ForegroundColor Yellow
+    Write-Host "Uso: .\\make.ps1 <setup|fetch|train|bt|paper|test>" -ForegroundColor Yellow
     exit 1
 }
 
-$venv = ".venv\Scripts\Activate.ps1"
+$venv = ".venv\\Scripts\\Activate.ps1"
+$python = "python"
+$symbols = @("BTC", "ETH")
 
 switch ($task.ToLower()) {
     "setup" {
         Write-Host "Creando entorno virtual..." -ForegroundColor Cyan
         if (-Not (Test-Path ".venv")) {
-            python -m venv .venv
+            & $python -m venv .venv
         } else {
             Write-Host "Entorno virtual ya existe" -ForegroundColor Yellow
         }
@@ -22,32 +24,32 @@ switch ($task.ToLower()) {
         pip install -r requirements.txt
     }
     "fetch" {
-        Write-Host "Descargando BTC y ETH (3650 días) via yfinance..." -ForegroundColor Cyan
         & $venv
-        python src\data_fetch.py --source yf --symbols BTC,ETH --days 3650
+        Write-Host "Descargando $($symbols -join ', ') (3650 días) via yfinance..." -ForegroundColor Cyan
+        & $python src\data_fetch.py --source yf --symbols $($symbols -join ',') --days 3650
     }
     "train" {
         & $venv
-        Write-Host "Entrenando LGBM para BTC..." -ForegroundColor Cyan
-        python src\ml\train_cli.py --model lgbm --csv data/BTC_USD_1d.csv --symbol BTC --window 30 --horizon 1
-        Write-Host "Entrenando LGBM para ETH..." -ForegroundColor Cyan
-        python src\ml\train_cli.py --model lgbm --csv data/ETH_USD_1d.csv --symbol ETH --window 30 --horizon 1
+        foreach ($sym in $symbols) {
+            Write-Host "Entrenando LGBM para $sym..." -ForegroundColor Cyan
+            & $python src\ml\train_cli.py --model lgbm --csv data/${sym}_USD_1d.csv --symbol $sym --window 30 --horizon 1
+        }
     }
     "bt" {
         & $venv
-        Write-Host "Backtest BTC con fee=0.006..." -ForegroundColor Cyan
-        python src\backtest\run_backtest.py --symbol BTC --csv data/BTC_USD_1d.csv --fee 0.006
-        Write-Host "Backtest ETH con fee=0.006..." -ForegroundColor Cyan
-        python src\backtest\run_backtest.py --symbol ETH --csv data/ETH_USD_1d.csv --fee 0.006
+        foreach ($sym in $symbols) {
+            Write-Host "Backtest $sym con fee=0.006..." -ForegroundColor Cyan
+            & $python src\backtest\run_backtest.py --symbol $sym --csv data/${sym}_USD_1d.csv --fee 0.006
+        }
     }
     "paper" {
-        Write-Host "Lanzando paper bot para BTC (intervalo 60 min)..." -ForegroundColor Cyan
         & $venv
-        python src\live\paper_bot.py --symbol BTC --csv data/BTC_USD_1d.csv --interval-minutes 60
+        Write-Host "Lanzando paper bot para BTC (intervalo 60 min)..." -ForegroundColor Cyan
+        & $python src\live\paper_bot.py --symbol BTC --csv data/BTC_USD_1d.csv --interval-minutes 60
     }
     "test" {
-        Write-Host "Ejecutando tests..." -ForegroundColor Cyan
         & $venv
+        Write-Host "Ejecutando tests..." -ForegroundColor Cyan
         pytest -q
     }
     Default {
@@ -55,3 +57,4 @@ switch ($task.ToLower()) {
         exit 1
     }
 }
+

--- a/sanity_e2e.ps1
+++ b/sanity_e2e.ps1
@@ -1,7 +1,7 @@
 # PowerShell script to run a full BTC workflow for sanity checking.
 
 # Step 1: environment setup
-$venv = ".venv\Scripts\Activate.ps1"
+$venv = ".venv\\Scripts\\Activate.ps1"
 Write-Host "Setting up environment..." -ForegroundColor Cyan
 if (-Not (Test-Path ".venv")) {
     python -m venv .venv
@@ -23,7 +23,13 @@ python src\ml\train_cli.py --model lgbm --csv data/BTC_USD_1d.csv --symbol BTC -
 Write-Host "Running BTC backtest..." -ForegroundColor Cyan
 python src\backtest\run_backtest.py --symbol BTC --csv data/BTC_USD_1d.csv --fee 0.006
 
-# Step 5: print summary path and total return
+# Step 5: short paper trading demo
+Write-Host "Launching paper bot demo..." -ForegroundColor Cyan
+$bot = Start-Process -FilePath "python" -ArgumentList "src\\live\\paper_bot.py --symbol BTC --csv data/BTC_USD_1d.csv --interval-minutes 1" -PassThru
+Start-Sleep -Seconds 5
+Stop-Process -Id $bot.Id
+
+# Step 6: print summary path and total return
 $summaryPath = Join-Path (Resolve-Path ".") "reports/BTC_summary.json"
 if (Test-Path $summaryPath) {
     $summary = Get-Content $summaryPath | ConvertFrom-Json
@@ -35,3 +41,4 @@ if (Test-Path $summaryPath) {
     Write-Host "Summary file not found: $summaryPath" -ForegroundColor Red
     exit 1
 }
+


### PR DESCRIPTION
## Summary
- refactor make.ps1 to centralize env setup and call data_fetch, train_cli, run_backtest, and paper_bot scripts
- extend sanity_e2e.ps1 to include a short paper bot demo after backtesting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68982d2a32908328ace8ce5c2ea1be03