### PR TITLE
feat: add technical indicators feature option

### DIFF
--- a/src/ml/feature_engineering.py
+++ b/src/ml/feature_engineering.py
@@ -1,4 +1,47 @@
 """Feature engineering utilities."""
 
-# TODO: Implement feature transformation functions
+from __future__ import annotations
 
+import pandas as pd
+
+
+def add_simple_returns(df: pd.DataFrame, price_col: str = "close", *, col_name: str = "return") -> pd.DataFrame:
+    """Add simple percentage returns to ``df``.
+
+    Parameters
+    ----------
+    df:
+        Input DataFrame containing a price column.
+    price_col:
+        Name of the column with close prices.
+    col_name:
+        Name of the generated return column.
+    """
+    df = df.copy()
+    df[col_name] = df[price_col].pct_change()
+    return df
+
+
+def add_tech_indicators(df: pd.DataFrame, price_col: str = "close") -> pd.DataFrame:
+    """Augment ``df`` with a small set of technical indicators.
+
+    The implementation purposefully keeps the computations lightweight; it is
+    sufficient for unit tests and small examples and does not aim to be
+    an exhaustive technical analysis library.
+    """
+    df = add_simple_returns(df, price_col)
+
+    # Simple moving averages
+    df["sma_5"] = df[price_col].rolling(5).mean()
+    df["sma_10"] = df[price_col].rolling(10).mean()
+
+    # Relative Strength Index (RSI)
+    delta = df[price_col].diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+    avg_gain = gain.rolling(14).mean()
+    avg_loss = loss.rolling(14).mean()
+    rs = avg_gain / avg_loss
+    df["rsi_14"] = 100 - 100 / (1 + rs)
+
+    return df

--- a/src/ml/train.py
+++ b/src/ml/train.py
@@ -19,6 +19,7 @@ import joblib
 import logging
 
 from src.utils.env import get_logs_dir, get_models_dir
+from .feature_engineering import add_simple_returns, add_tech_indicators
 
 
 logger = logging.getLogger(__name__)
@@ -136,6 +137,7 @@ def train_evaluate(
     model_type: str,
     horizon: int,
     window: int,
+    feature_set: str = "returns",
     outdir: str = str(get_models_dir()),
 ) -> None:
     """Train a trivial model and persist artefacts.
@@ -180,8 +182,16 @@ def train_evaluate(
         logger.error("CSV must contain a 'target' column")
         raise ValueError("CSV must contain a 'target' column")
 
+    if feature_set == "indicators":
+        df = add_tech_indicators(df)
+        feature_cols = [c for c in df.columns if c not in {"target", "date", "close"}]
+    else:
+        df = add_simple_returns(df)
+        feature_cols = ["return"]
+
+    df = df.dropna(subset=feature_cols + ["target"])
     dates = pd.to_datetime(df["date"]) if "date" in df.columns else None
-    X = df.drop(columns=[col for col in ["target", "date"] if col in df.columns])
+    X = df[feature_cols]
     y = df["target"]
 
     X_train, X_test, y_train, y_test, dates_train, dates_test = train_test_split(

--- a/src/ml/train_cli.py
+++ b/src/ml/train_cli.py
@@ -47,6 +47,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Window size for features",
     )
     parser.add_argument(
+        "--features",
+        choices=["returns", "indicators"],
+        default="returns",
+        help="Feature set to use",
+    )
+    parser.add_argument(
         "--outdir",
         default=str(get_models_dir()),
         help="Directory where artefacts will be stored",
@@ -63,6 +69,7 @@ def main(args: list[str] | None = None) -> None:
         model_type=parsed.model,
         horizon=parsed.horizon,
         window=parsed.window,
+        feature_set=parsed.features,
         outdir=parsed.outdir,
     )
 


### PR DESCRIPTION
## Summary
- implement simple returns and technical indicator generators
- build feature matrices consistently and expose CLI flag to choose feature set
- ensure SignalStrategy selects trained feature columns when predicting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a044ee688328887d0fe38ba93267