### PR TITLE
Unify temporal data split and expand look-ahead tests

### DIFF
--- a/src/ml/train.py
+++ b/src/ml/train.py
@@ -154,7 +154,7 @@ def train_evaluate(
         roc_auc_score,
         roc_curve,
     )
-    from sklearn.model_selection import train_test_split
+    from src.ml.data_utils import temporal_train_test_split
     import matplotlib.pyplot as plt
 
     logger.info("Training %s model for %s", model_type, symbol)
@@ -184,12 +184,11 @@ def train_evaluate(
     X = df.drop(columns=[col for col in ["target", "date"] if col in df.columns])
     y = df["target"]
 
-    X_train, X_test, y_train, y_test, dates_train, dates_test = train_test_split(
+    X_train, X_test, y_train, y_test, dates_train, dates_test = temporal_train_test_split(
         X,
         y,
         dates,
         test_size=0.2,
-        shuffle=False,
     )
 
     model = DummyClassifier(strategy="most_frequent")

--- a/tests/test_dataset_no_lookahead.py
+++ b/tests/test_dataset_no_lookahead.py
@@ -4,8 +4,10 @@ from src.ml.data_utils import make_lagged_features, temporal_train_test_split
 
 
 def test_temporal_split_and_no_lookahead():
-    series = pd.Series(range(10), name="price")
+    index = pd.date_range("2020-01-01", periods=10)
+    series = pd.Series(range(10), index=index, name="price")
     X, y = make_lagged_features(series, window=3)
+    dates = pd.Series(X.index, index=X.index, name="date")
 
     # First row should contain only past information
     assert X.iloc[0].tolist() == [2, 1, 0]
@@ -14,8 +16,11 @@ def test_temporal_split_and_no_lookahead():
     # The label must be greater than any feature for this monotonic series
     assert (X.max(axis=1) < y).all()
 
-    X_train, X_test, y_train, y_test = temporal_train_test_split(X, y, test_size=0.3)
+    X_train, X_test, y_train, y_test, dates_train, dates_test = temporal_train_test_split(
+        X, y, dates, test_size=0.3
+    )
 
     # Ensure chronological split without shuffling
     assert X_train.index.max() < X_test.index.min()
     assert y_train.index.max() < y_test.index.min()
+    assert dates_train.max() < dates_test.min()


### PR DESCRIPTION
## Summary
- Generalize `temporal_train_test_split` to handle multiple arrays while preserving order
- Use the shared split helper in the training script instead of `sklearn.train_test_split`
- Extend dataset test with date splits to assert no look-ahead

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a04b527083288c8acea356b94013