### PR TITLE
Enhance backtest metrics and risk model

### DIFF
--- a/src/backtest/engine.py
+++ b/src/backtest/engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from math import sqrt
 from typing import List, Tuple
 
 import pandas as pd
@@ -27,6 +28,8 @@ def backtest_spot(
     fee: float = 0.0,
     slippage: float = 0.0,  # pragma: no cover - reserved for future use
     initial_cash: float = 1000.0,
+    risk_per_trade: float = 1.0,
+    stop_loss: float | None = None,
 ) -> Tuple[dict, pd.Series, pd.DataFrame]:
     """Run a tiny spot backtest driven by ``signal`` column.
 
@@ -40,30 +43,93 @@ def backtest_spot(
         Currently unused but kept for API compatibility.
     initial_cash:
         Starting cash for the backtest.
+    risk_per_trade:
+        Fraction of available cash to deploy on each trade.
+    stop_loss:
+        Optional stop loss expressed as a decimal percentage from entry price.
     """
 
     cash = initial_cash
     position = 0.0
-    equity_curve = []
+    equity_curve: list[float] = []
     trades: TradeList = []
+    trade_profits: list[float] = []
+
+    entry_cost = 0.0
+    stop_price = None
 
     for ts, row in df.iterrows():
         price = float(row["close"])
         signal = row.get("signal", "HOLD")
 
-        if signal == "BUY" and cash >= price * (1 + fee):
-            qty = 1.0
-            cash -= price * (1 + fee)
-            position += qty
-            trades.append(Trade(ts, "BUY", price, qty))
-        elif signal == "SELL" and position >= 1.0:
-            cash += price * (1 - fee) * 1.0
-            trades.append(Trade(ts, "SELL", price, 1.0))
-            position -= 1.0
+        # Check stop loss first
+        if position > 0 and stop_loss is not None and price <= stop_price:  # type: ignore[arg-type]
+            proceeds = position * price * (1 - fee)
+            cash += proceeds
+            profit = proceeds - entry_cost
+            trade_profits.append(profit)
+            trades.append(Trade(ts, "SELL", price, position))
+            position = 0.0
+            entry_cost = 0.0
+            stop_price = None
+
+        # Trading signals
+        if signal == "BUY" and cash > 0 and position == 0:
+            cash_to_use = cash * risk_per_trade
+            qty = cash_to_use / (price * (1 + fee))
+            if qty > 0:
+                cost = qty * price * (1 + fee)
+                cash -= cost
+                position = qty
+                entry_cost = cost
+                if stop_loss is not None:
+                    stop_price = price * (1 - stop_loss)
+                trades.append(Trade(ts, "BUY", price, qty))
+        elif signal == "SELL" and position > 0:
+            proceeds = position * price * (1 - fee)
+            cash += proceeds
+            profit = proceeds - entry_cost
+            trade_profits.append(profit)
+            trades.append(Trade(ts, "SELL", price, position))
+            position = 0.0
+            entry_cost = 0.0
+            stop_price = None
 
         equity_curve.append(cash + position * price)
 
-    summary = {"final_equity": equity_curve[-1] if equity_curve else initial_cash}
     equity = pd.Series(equity_curve, index=df.index, name="equity")
+
+    final_equity = equity.iloc[-1] if not equity.empty else initial_cash
+    periods = len(equity)
+    years = periods / 252 if periods else 0
+    cagr = (final_equity / initial_cash) ** (1 / years) - 1 if years else 0.0
+
+    roll_max = equity.cummax()
+    drawdown = equity / roll_max - 1.0
+    max_dd = drawdown.min() if not drawdown.empty else 0.0
+
+    returns = equity.pct_change().dropna()
+    sharpe = (
+        returns.mean() / returns.std() * sqrt(252)
+        if not returns.empty and returns.std() != 0
+        else 0.0
+    )
+
+    num_trades = len(trade_profits)
+    win_rate = (
+        sum(p > 0 for p in trade_profits) / num_trades if num_trades else 0.0
+    )
+    avg_profit = sum(trade_profits) / num_trades if num_trades else 0.0
+
+    summary = {
+        "final_equity": final_equity,
+        "CAGR": cagr,
+        "max_drawdown": max_dd,
+        "sharpe": sharpe,
+        "win_rate": win_rate,
+        "num_trades": num_trades,
+        "avg_profit_per_trade": avg_profit,
+    }
+
     trades_df = pd.DataFrame(trades)
     return summary, equity, trades_df

--- a/tests/test_engine_accounting.py
+++ b/tests/test_engine_accounting.py
@@ -13,6 +13,7 @@ def test_no_signal_has_constant_equity_and_no_trades():
     assert trades.empty
     assert (equity == 100).all()
     assert summary["final_equity"] == 100
+    assert summary["num_trades"] == 0
 
 
 def test_buy_then_sell_with_fee():
@@ -21,8 +22,25 @@ def test_buy_then_sell_with_fee():
         "signal": ["BUY", "SELL"],
     })
     summary, equity, trades = backtest_spot(df, fee=0.01, initial_cash=1000)
-    # Two trades: buy and sell
+    # Two records: buy and sell
     assert len(trades) == 2
-    # Expected PnL accounting for fees
-    expected_final = 1000 - 10 * (1 + 0.01) + 12 * (1 - 0.01)
+    qty = 1000 / (10 * (1 + 0.01))
+    expected_final = qty * 12 * (1 - 0.01)
+    assert summary["final_equity"] == pytest.approx(expected_final)
+    assert summary["num_trades"] == 1
+    assert summary["win_rate"] == pytest.approx(1.0)
+
+
+def test_stop_loss_triggered():
+    df = pd.DataFrame({
+        "close": [10, 9],
+        "signal": ["BUY", "HOLD"],
+    })
+    summary, equity, trades = backtest_spot(
+        df, fee=0.01, initial_cash=1000, stop_loss=0.05
+    )
+    assert summary["num_trades"] == 1
+    assert summary["win_rate"] == 0.0
+    qty = 1000 / (10 * (1 + 0.01))
+    expected_final = qty * 9 * (1 - 0.01)
     assert summary["final_equity"] == pytest.approx(expected_final)


### PR DESCRIPTION
## Summary
- Extend `backtest_spot` with capital-based position sizing via `risk_per_trade` and optional stop-loss handling
- Compute comprehensive performance metrics including CAGR, max drawdown, Sharpe ratio, win rate, trade count, and average profit per trade
- Expand unit tests to cover new sizing logic and stop-loss behaviour

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898a055e5ec8328ae5cb4ecc9bb2b61