### PR TITLE
Add live trading mode with risk controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,13 @@ un modelo y generación de señales para backtesting y paper trading.
    ```powershell
    python -m src.backtest.run_backtest --symbol BTC --csv data/BTC_USD_1d.csv
    ```
-4. **Paper** – Lanzar el bot de paper trading:
+4. **Paper/Live** – Lanzar el bot de trading:
    ```powershell
-   python -m src.live.paper_bot --symbol BTC --csv data/BTC_USD_1d.csv
+   # Paper (modo por defecto)
+   python -m src.live.paper_bot --symbol BTC/USDT --csv data/BTC_USDT_1d.csv
+
+   # Live (requiere credenciales y un exchange soportado por ccxt)
+   python -m src.live.paper_bot --symbol BTC/USDT --csv data/BTC_USDT_1d.csv --mode live --exchange binance
    ```
 
 ## Artefactos y reportes
@@ -41,16 +45,16 @@ un modelo y generación de señales para backtesting y paper trading.
   `report.json`, `diagnostic.png`)
 - **Backtests**: `reports/{symbol}_summary.json`,
   `reports/{symbol}_equity.png`, `reports/{symbol}_trades.csv`
-- **Paper bot**: `reports/paper_bot_{symbol}.csv`
+- **Bot de trading**: `reports/paper_bot_{symbol}.csv`
 - **Logs**: `logs/data_fetch.log`, `logs/paper_bot.log`
 
 ## Ajustar fees y umbrales
 
 - **Backtest**: parámetros `--fee`, `--slippage`, `--buy-thr`, `--sell-thr` y
   `--min-edge` de `src/backtest/run_backtest.py`.
-- **Paper bot**: constantes `FEE_RATE` y `SLIPPAGE`, y valores `buy_thr`,
-  `sell_thr` y `min_edge` al instanciar `SignalStrategy` en
-  `src/live/paper_bot.py`.
+- **Bot de trading**: constantes `FEE_RATE` y `SLIPPAGE`, valores `buy_thr`,
+  `sell_thr` y `min_edge` al instanciar `SignalStrategy`, además de las
+  opciones `--mode`, `--exchange`, `--max-allocation` y `--max-drawdown`.
 
 ## Módulos experimentales
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas
 requests
 yfinance
 python-dotenv
+ccxt

--- a/src/live/paper_bot.py
+++ b/src/live/paper_bot.py
@@ -1,15 +1,17 @@
-"""Paper trading bot for live data using a trained ``SignalStrategy``.
+"""Trading bot for live data using a trained ``SignalStrategy``.
 
-The bot periodically reads the most recent data from a CSV file, generates a
-trading signal and simulates trades on a paper account.  Portfolio snapshots
-are appended to ``reports/`` and actions are logged to
-``logs/paper_bot.log``.
+The bot can operate in *paper* mode, simulating trades on a virtual account,
+or in *live* mode by sending orders to a real exchange client.  The program
+periodically reads the most recent data from a CSV file, generates a trading
+signal and executes trades accordingly.  Portfolio snapshots are appended to
+``reports/`` and actions are logged to ``logs/paper_bot.log``.
 """
 
 from __future__ import annotations
 
 import argparse
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Tuple
@@ -29,15 +31,33 @@ logger = logging.getLogger(__name__)
 def _parse_args() -> argparse.Namespace:
     """Build command line parser."""
 
-    parser = argparse.ArgumentParser(description="Run paper trading bot")
-    parser.add_argument("--symbol", required=True, help="Trading symbol")
+    parser = argparse.ArgumentParser(description="Run trading bot")
+    parser.add_argument("--symbol", required=True, help="Trading symbol, e.g. BTC/USDT")
+    parser.add_argument("--csv", required=True, help="Path to CSV with market data")
     parser.add_argument(
         "--interval-minutes", type=int, default=60, help="Polling interval in minutes"
     )
     parser.add_argument(
         "--window", type=int, default=30, help="Lookback window length"
     )
-    parser.add_argument("--csv", required=True, help="Path to CSV with market data")
+    parser.add_argument(
+        "--mode", choices=["paper", "live"], default="paper", help="Trading mode"
+    )
+    parser.add_argument(
+        "--exchange", default="binance", help="Exchange name for live mode"
+    )
+    parser.add_argument(
+        "--max-allocation",
+        type=float,
+        default=1.0,
+        help="Fraction of equity to allocate per trade",
+    )
+    parser.add_argument(
+        "--max-drawdown",
+        type=float,
+        default=0.02,
+        help="Daily drawdown fraction triggering kill switch",
+    )
     return parser.parse_args()
 
 
@@ -55,6 +75,54 @@ def _read_window(path: str, window: int) -> Tuple[pd.DataFrame, pd.Series]:
     return df, df.iloc[-1]
 
 
+class RiskManager:
+    """Track equity highs and stop when drawdown exceeds a threshold."""
+
+    def __init__(self, max_drawdown: float):
+        self.max_drawdown = max_drawdown
+        self.daily_high: float | None = None
+        self.last_day: pd.Timestamp | None = None
+
+    def check(self, equity: float, now: pd.Timestamp) -> bool:
+        """Return ``True`` to continue trading, ``False`` to stop."""
+
+        if self.last_day is None or now.date() != self.last_day.date():
+            self.daily_high = equity
+            self.last_day = now
+        assert self.daily_high is not None
+        self.daily_high = max(self.daily_high, equity)
+        if equity < self.daily_high * (1 - self.max_drawdown):
+            logger.warning(
+                "Daily drawdown exceeded %.2f%%", self.max_drawdown * 100
+            )
+            return False
+        return True
+
+
+def _init_exchange_client(exchange: str):  # pragma: no cover - thin wrapper
+    """Return a ccxt client for ``exchange`` using env credentials."""
+
+    import ccxt  # type: ignore
+
+    cls = getattr(ccxt, exchange)
+    return cls(
+        {
+            "apiKey": os.getenv("EXCHANGE_API_KEY"),
+            "secret": os.getenv("EXCHANGE_API_SECRET"),
+        }
+    )
+
+
+def _fetch_balances(client, symbol: str) -> Tuple[float, float]:
+    """Return cash and asset quantity from the exchange."""
+
+    base, quote = symbol.split("/")
+    bal = client.fetch_balance()
+    cash = float(bal[quote]["free"])
+    asset_qty = float(bal[base]["free"])
+    return cash, asset_qty
+
+
 def main() -> None:  # pragma: no cover - CLI entry point
     args = _parse_args()
 
@@ -65,22 +133,29 @@ def main() -> None:  # pragma: no cover - CLI entry point
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
 
-    logger.info("Starting paper bot for %s", args.symbol)
+    logger.info("Starting %s bot for %s", args.mode, args.symbol)
     try:
         strat = SignalStrategy(args.symbol)
     except Exception as exc:  # pragma: no cover - best effort logging
         logger.exception("Failed to load strategy: %s", exc)
         return
-    cash = 10_000.0
-    asset_qty = 0.0
+    risk = RiskManager(args.max_drawdown)
+
+    if args.mode == "live":
+        try:  # pragma: no cover - best effort logging
+            client = _init_exchange_client(args.exchange)
+        except Exception as exc:  # pragma: no cover - best effort logging
+            logger.exception("Failed to init exchange client: %s", exc)
+            return
+        cash = asset_qty = 0.0
+    else:
+        cash = 10_000.0
+        asset_qty = 0.0
     equity = cash
 
     report_path = get_reports_dir() / f"paper_bot_{args.symbol}.csv"
     _ensure_dirs(str(report_path))
     write_header = not report_path.exists()
-
-    daily_high = equity
-    last_day = None
 
     while True:
         try:
@@ -117,18 +192,48 @@ def main() -> None:  # pragma: no cover - CLI entry point
             signal = "HOLD"
 
         price = float(last["close"])
-        if signal == "BUY" and cash > 0:
-            trade_price = price * (1 + SLIPPAGE)
-            qty = (cash * (1 - FEE_RATE)) / trade_price
-            asset_qty += qty
-            cash = 0.0
-        elif signal == "SELL" and asset_qty > 0:
-            trade_price = price * (1 - SLIPPAGE)
-            proceeds = asset_qty * trade_price * (1 - FEE_RATE)
-            cash += proceeds
-            asset_qty = 0.0
+
+        if args.mode == "live":
+            try:
+                cash, asset_qty = _fetch_balances(client, args.symbol)
+            except Exception as exc:  # pragma: no cover - best effort logging
+                logger.exception("Failed to fetch balances: %s", exc)
+                time.sleep(args.interval_minutes * 60)
+                continue
 
         equity = cash + asset_qty * price
+
+        if signal == "BUY" and cash > 0:
+            trade_value = min(cash, equity * args.max_allocation)
+            if trade_value > 0:
+                if args.mode == "paper":
+                    trade_price = price * (1 + SLIPPAGE)
+                    qty = (trade_value * (1 - FEE_RATE)) / trade_price
+                    asset_qty += qty
+                    cash -= trade_value
+                else:
+                    qty = trade_value / price
+                    try:  # pragma: no cover - best effort logging
+                        client.create_market_buy_order(args.symbol, qty)
+                    except Exception as exc:  # pragma: no cover
+                        logger.exception("Live buy failed: %s", exc)
+                    cash, asset_qty = _fetch_balances(client, args.symbol)
+                equity = cash + asset_qty * price
+        elif signal == "SELL" and asset_qty > 0:
+            qty_to_sell = asset_qty * args.max_allocation
+            if qty_to_sell > 0:
+                if args.mode == "paper":
+                    trade_price = price * (1 - SLIPPAGE)
+                    proceeds = qty_to_sell * trade_price * (1 - FEE_RATE)
+                    cash += proceeds
+                    asset_qty -= qty_to_sell
+                else:
+                    try:  # pragma: no cover - best effort logging
+                        client.create_market_sell_order(args.symbol, qty_to_sell)
+                    except Exception as exc:  # pragma: no cover
+                        logger.exception("Live sell failed: %s", exc)
+                    cash, asset_qty = _fetch_balances(client, args.symbol)
+                equity = cash + asset_qty * price
 
         logger.info(
             "price=%.2f p_up=%.4f signal=%s cash=%.2f qty=%.6f equity=%.2f",
@@ -162,15 +267,8 @@ def main() -> None:  # pragma: no cover - CLI entry point
             write_header = False
 
         now = pd.Timestamp.utcnow()
-        if last_day is None or now.date() != last_day:
-            daily_high = equity
-            last_day = now.date()
-        daily_high = max(daily_high, equity)
-        if equity < daily_high * (1 - 0.02):
-            logger.warning("Daily drawdown exceeded 2%%, pausing 24h")
-            time.sleep(24 * 60 * 60)
-            daily_high = equity
-            last_day = pd.Timestamp.utcnow().date()
+        if not risk.check(equity, now):
+            break
 
         time.sleep(args.interval_minutes * 60)
 

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+from src.live.paper_bot import RiskManager
+
+
+def test_risk_manager_triggers_on_drawdown():
+    rm = RiskManager(0.1)
+    now = pd.Timestamp("2024-01-01")
+    assert rm.check(100, now)
+    assert rm.check(110, now)
+    # Drawdown below 10% from high (110 -> threshold 99)
+    assert not rm.check(98, now)
+
+
+def test_risk_manager_resets_each_day():
+    rm = RiskManager(0.05)
+    day1 = pd.Timestamp("2024-01-01")
+    day2 = pd.Timestamp("2024-01-02")
+    assert rm.check(100, day1)
+    assert rm.check(110, day1)
+    # New day resets high
+    assert rm.check(100, day2)


### PR DESCRIPTION
## Summary
- allow selecting paper or live trading modes via CLI
- integrate ccxt exchange client with configurable risk allocation and daily drawdown kill switch
- add unit tests for new risk manager and update docs

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898a06bfbb48328b9cee35355517b8e