### PR TITLE
Add LightGBM and LSTM training support

### DIFF
--- a/src/ml/models_wrappers.py
+++ b/src/ml/models_wrappers.py
@@ -1,4 +1,41 @@
+"""Model wrapper utilities.
+
+This module contains small helper classes that provide a consistent interface
+across different machine learning libraries.  They are intentionally minimal
+and only implement the parts of the scikit-learn API that are required by the
+unit tests and the training script.
+"""
+
+from __future__ import annotations
+
 import numpy as np
+
+
+class LGBMClassifierModel:
+    """Thin wrapper around :class:`lightgbm.LGBMClassifier`.
+
+    The project prefers to keep third-party dependencies lightweight.  Rather
+    than exposing the LightGBM estimator directly we wrap it in a tiny class
+    that mimics the parts of the scikit-learn API we rely on.  This keeps the
+    training code agnostic of the underlying library while still performing a
+    real gradient boosting training run.
+    """
+
+    def __init__(self, **params: dict):
+        from lightgbm import LGBMClassifier
+
+        self.model = LGBMClassifier(**params)
+
+    def fit(self, X, y):  # pragma: no cover - simple passthrough
+        self.model.fit(X, y)
+        return self
+
+    def predict(self, X):  # pragma: no cover - simple passthrough
+        return self.model.predict(X)
+
+    def predict_proba(self, X):  # pragma: no cover - simple passthrough
+        return self.model.predict_proba(X)
+
 
 # Usado por tests/test_predict_proba.py
 


### PR DESCRIPTION
## Summary
- add `LGBMClassifierModel` wrapper to unify LightGBM API usage
- enhance `train` to persist real Keras models to `.h5` while still exporting `model.pkl`
- extend `train_evaluate` to train either LightGBM or LSTM models with scaling and sequence handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a26833988328a51d01a82c8669cc