### PR TITLE
Enforce strategy hysteresis and cost coverage

### DIFF
--- a/src/backtest/run_backtest.py
+++ b/src/backtest/run_backtest.py
@@ -76,12 +76,14 @@ def main() -> None:
         return
 
     try:
+        costs = (args.fee + args.slippage) * 2
         strategy = SignalStrategy(
             args.symbol,
             model_dir=str(get_models_dir()),
             buy_thr=args.buy_thr,
             sell_thr=args.sell_thr,
             min_edge=args.min_edge,
+            costs=costs,
         )
     except Exception as exc:  # pragma: no cover - best effort logging
         logger.exception("Failed to initialise strategy: %s", exc)

--- a/src/backtest/strategy.py
+++ b/src/backtest/strategy.py
@@ -19,6 +19,11 @@ class SignalStrategy:
     The class normally expects a ``symbol`` string and loads the
     corresponding model artefacts from ``model_dir``.  For testing purposes
     a model instance can be supplied directly as the first argument.
+
+    ``buy_thr`` must be strictly greater than ``sell_thr`` to provide
+    hysteresis, avoiding rapid flip-flopping between buy and sell signals.
+    ``min_edge`` represents the minimum edge over 0.5 required to act and
+    must at least cover ``costs`` (e.g. fees and slippage).
     """
 
     def __init__(
@@ -30,10 +35,17 @@ class SignalStrategy:
         buy_thr: float = 0.6,
         sell_thr: float = 0.4,
         min_edge: float = 0.02,
+        costs: float = 0.0,
     ) -> None:
+        if buy_thr <= sell_thr:
+            raise ValueError("buy_thr must be greater than sell_thr for hysteresis")
+        if min_edge < costs:
+            raise ValueError("min_edge must be greater or equal to costs")
+
         self.buy_thr = buy_thr
         self.sell_thr = sell_thr
         self.min_edge = min_edge
+        self.costs = costs
 
 
         if isinstance(symbol_or_model, str):

--- a/src/live/paper_bot.py
+++ b/src/live/paper_bot.py
@@ -136,7 +136,8 @@ def main() -> None:  # pragma: no cover - CLI entry point
 
     logger.info("Starting %s bot for %s", args.mode, args.symbol)
     try:
-        strat = SignalStrategy(args.symbol)
+        costs = (FEE_RATE + SLIPPAGE) * 2
+        strat = SignalStrategy(args.symbol, costs=costs)
     except Exception as exc:  # pragma: no cover - best effort logging
         logger.exception("Failed to load strategy: %s", exc)
         notify(f"Failed to load strategy: {exc}")

--- a/tests/test_strategy_hysteresis.py
+++ b/tests/test_strategy_hysteresis.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from src.backtest.strategy import SignalStrategy
 
@@ -21,3 +22,13 @@ def test_hysteresis_prevents_flip_flop():
     assert strat.generate_signal(df) == "HOLD"
     assert strat.generate_signal(df) == "HOLD"
     assert strat.generate_signal(df) == "SELL"
+
+
+def test_buy_thr_must_exceed_sell_thr():
+    with pytest.raises(ValueError):
+        SignalStrategy(SeqModel([0.5]), buy_thr=0.4, sell_thr=0.4)
+
+
+def test_min_edge_must_cover_costs():
+    with pytest.raises(ValueError):
+        SignalStrategy(SeqModel([0.5]), buy_thr=0.6, sell_thr=0.4, min_edge=0.01, costs=0.02)


### PR DESCRIPTION
## Summary
- validate that trading strategy uses hysteresis (buy threshold must exceed sell threshold) and that minimum edge covers fees and slippage
- pass estimated round-trip costs to the strategy in backtests and paper trading bot
- test invalid thresholds and cost handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898a689deac8328a78a2e0ae9d6a1dc