### PR TITLE
Add rotating file logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ un modelo y generación de señales para backtesting y paper trading.
 - **Backtests**: `reports/{symbol}_summary.json`,
   `reports/{symbol}_equity.png`, `reports/{symbol}_trades.csv`
 - **Bot de trading**: `reports/paper_bot_{symbol}.csv`
-- **Logs**: `logs/data_fetch.log`, `logs/paper_bot.log`
+- **Logs**: `logs/*.log` (rotados automáticamente)
 
 ## Ajustar fees y umbrales
 

--- a/src/backtest/run_backtest.py
+++ b/src/backtest/run_backtest.py
@@ -1,20 +1,16 @@
 import argparse
 import json
 import logging
-from pathlib import Path
 
 import pandas as pd
 
 from .strategy import SignalStrategy
 from src.backtest.engine import backtest_spot
-from src.utils.env import get_logs_dir, get_models_dir, get_reports_dir
+from src.utils.env import get_models_dir, get_reports_dir
+from src.utils.logging_config import setup_logging
 
 
 logger = logging.getLogger(__name__)
-
-
-def _ensure_dirs(path: str) -> None:
-    Path(path).parent.mkdir(parents=True, exist_ok=True)
 
 
 def parse_args() -> argparse.Namespace:
@@ -58,12 +54,7 @@ def main() -> None:
         args.min_edge = cfg.get("min_edge", args.min_edge)
         args.window_size = cfg.get("window", cfg.get("window_size", args.window_size))
 
-    _ensure_dirs(str(get_logs_dir() / "run_backtest.log"))
-    logging.basicConfig(
-        filename=str(get_logs_dir() / "run_backtest.log"),
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
+    setup_logging("run_backtest")
 
     logger.info("Starting backtest for %s", args.symbol)
     try:

--- a/src/data_fetch.py
+++ b/src/data_fetch.py
@@ -16,7 +16,8 @@ from typing import Callable, Dict, List
 
 import pandas as pd
 
-from src.utils.env import get_data_dir, get_logs_dir
+from src.utils.env import get_data_dir
+from src.utils.logging_config import setup_logging
 from src.utils.market_data import fetch_coingecko_ohlc, fetch_yf_ohlc
 
 
@@ -79,12 +80,7 @@ def _fetch_with_retry(func: Callable[..., pd.DataFrame], *args, **kwargs) -> pd.
 def main() -> None:
     args = _parse_args()
 
-    _ensure_dirs(str(get_logs_dir() / "data_fetch.log"))
-    logging.basicConfig(
-        filename=str(get_logs_dir() / "data_fetch.log"),
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
+    setup_logging("data_fetch")
 
     symbols: List[str] = [s.strip().upper() for s in args.symbols.split(",") if s.strip()]
     fetchers: Dict[str, Callable[[str, str, str], pd.DataFrame]] = {

--- a/src/live/paper_bot.py
+++ b/src/live/paper_bot.py
@@ -19,7 +19,8 @@ from typing import Tuple
 import pandas as pd
 
 from src.backtest.strategy import SignalStrategy
-from src.utils.env import get_logs_dir, get_reports_dir
+from src.utils.env import get_reports_dir
+from src.utils.logging_config import setup_logging
 from src.utils.notify import notify
 
 FEE_RATE = 0.006
@@ -127,12 +128,7 @@ def _fetch_balances(client, symbol: str) -> Tuple[float, float]:
 def main() -> None:  # pragma: no cover - CLI entry point
     args = _parse_args()
 
-    _ensure_dirs(str(get_logs_dir() / "paper_bot.log"))
-    logging.basicConfig(
-        filename=str(get_logs_dir() / "paper_bot.log"),
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
+    setup_logging("paper_bot")
 
     logger.info("Starting %s bot for %s", args.mode, args.symbol)
     try:

--- a/src/ml/train.py
+++ b/src/ml/train.py
@@ -18,23 +18,15 @@ import importlib
 import joblib
 import logging
 
-from src.utils.env import get_logs_dir, get_models_dir
+from src.utils.env import get_models_dir
+from src.utils.logging_config import setup_logging
 from .feature_engineering import add_simple_returns, add_tech_indicators
 
 
 logger = logging.getLogger(__name__)
 
 
-def _ensure_dirs(path: str) -> None:
-    Path(path).parent.mkdir(parents=True, exist_ok=True)
-
-
-_ensure_dirs(str(get_logs_dir() / "train.log"))
-logging.basicConfig(
-    filename=str(get_logs_dir() / "train.log"),
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-)
+setup_logging("train")
 
 
 class _IdentityScaler:

--- a/src/utils/logging_config.py
+++ b/src/utils/logging_config.py
@@ -1,0 +1,28 @@
+import logging
+from logging.handlers import RotatingFileHandler
+
+from .env import get_logs_dir
+
+
+def setup_logging(name: str, level: int = logging.INFO) -> None:
+    """Configure root logging to a rotating file in ``logs/``.
+
+    Parameters
+    ----------
+    name:
+        Base filename for the log. The log file will be ``logs/<name>.log``.
+    level:
+        Logging level for the root logger. Defaults to ``logging.INFO``.
+    """
+    logs_dir = get_logs_dir()
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    log_path = logs_dir / f"{name}.log"
+
+    handler = RotatingFileHandler(log_path, maxBytes=1_000_000, backupCount=3)
+    formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+    handler.setFormatter(formatter)
+
+    root = logging.getLogger()
+    root.setLevel(level)
+    root.handlers = []
+    root.addHandler(handler)


### PR DESCRIPTION
## Summary
- add helper to configure rotating log files under logs/
- use helper in CLI scripts (data_fetch, run_backtest, train, paper_bot)
- document automatic log rotation in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898a690c24c8328857febd7a0888405