### PR TITLE
feat: add unified feature pipeline with lags and tech options

### DIFF
--- a/src/ml/feature_engineering.py
+++ b/src/ml/feature_engineering.py
@@ -3,6 +3,36 @@
 from __future__ import annotations
 
 import pandas as pd
+from typing import Tuple
+
+
+def make_lagged_features(
+    series: pd.Series, window: int
+) -> Tuple[pd.DataFrame, pd.Series]:
+    """Create lagged features for a univariate series.
+
+    Parameters
+    ----------
+    series:
+        Input time series to lag. The current value will be dropped so that
+        each row only contains information strictly from the past.
+    window:
+        Number of past observations to include as features.
+
+    Returns
+    -------
+    X, y:
+        Feature ``DataFrame`` where each column represents a lagged value and
+        the corresponding target ``Series`` aligned such that ``y_t`` depends
+        only on values strictly prior to ``t``.
+    """
+    data = {f"lag_{i}": series.shift(i) for i in range(1, window + 1)}
+    X = pd.DataFrame(data)
+    y = series.copy()
+    df = pd.concat([X, y], axis=1).dropna()
+    X = df[[f"lag_{i}" for i in range(1, window + 1)]]
+    y = df[series.name]
+    return X, y
 
 
 def add_simple_returns(df: pd.DataFrame, price_col: str = "close", *, col_name: str = "return") -> pd.DataFrame:

--- a/src/ml/train_cli.py
+++ b/src/ml/train_cli.py
@@ -48,8 +48,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--features",
-        choices=["returns", "indicators"],
-        default="returns",
+        choices=["lags", "tech"],
+        default="lags",
         help="Feature set to use",
     )
     parser.add_argument(

--- a/tests/test_build_features.py
+++ b/tests/test_build_features.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+from src.ml.data_utils import build_features
+
+
+def test_build_features_lags_order():
+    df = pd.DataFrame({"close": range(10), "target": range(10)})
+    X, y, cols = build_features(df, feature_set="lags", window=3)
+    assert cols == ["lag_1", "lag_2", "lag_3"]
+    assert list(X.columns) == cols
+    assert len(X) == len(y)
+
+
+def test_build_features_tech_order():
+    # Create enough rows so moving averages and RSI are defined
+    n = 30
+    df = pd.DataFrame({"close": range(n), "target": [0] * n})
+    X, y, cols = build_features(df, feature_set="tech")
+    assert cols == ["return", "sma_5", "sma_10", "rsi_14"]
+    assert list(X.columns) == cols
+    assert len(X) == len(y)


### PR DESCRIPTION
## Summary
- add `make_lagged_features` to feature engineering module
- build features from lags or technical indicators via shared pipeline
- expose `--features {lags,tech}` in CLI
- test feature order for lags and technical indicators

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a675440083289c62b1cb6b25f4cc