### PR TITLE
Add missing utilities and fix backtest reporting

### DIFF
--- a/src/backtest/engine.py
+++ b/src/backtest/engine.py
@@ -74,8 +74,9 @@ def backtest_spot(
                 entry_price = None
 
         if signal == "BUY" and cash >= price * (1 + fee) and position == 0.0:
-            qty = cash * position_pct / (price * (1 + fee))
-            cash -= qty * price * (1 + fee)
+            buy_price = price * (1 + slippage)
+            qty = cash * position_pct / (buy_price * (1 + fee))
+            cash -= qty * buy_price * (1 + fee)
             position += qty
             entry_price = buy_price
             trades.append(Trade(ts, "BUY", buy_price, qty))
@@ -83,12 +84,11 @@ def backtest_spot(
             sell_price = price * (1 - slippage)
             cash += position * sell_price * (1 - fee)
             if entry_price is None:
-
-                entry_price = price
+                entry_price = sell_price
             trade_returns.append(
-                price * (1 - fee) / (entry_price * (1 + fee)) - 1
+                sell_price * (1 - fee) / (entry_price * (1 + fee)) - 1
             )
-            trades.append(Trade(ts, "SELL", price, position))
+            trades.append(Trade(ts, "SELL", sell_price, position))
             position = 0.0
             entry_price = None
 

--- a/src/utils/env.py
+++ b/src/utils/env.py
@@ -1,48 +1,29 @@
-"""Helpers for accessing configuration and project directories.
-
-This module provides a thin wrapper around :mod:`configs.settings` so that
-other parts of the codebase can easily access common paths (and later
-credentials) without needing to know about the underlying settings
-implementation.
-"""
-
 from __future__ import annotations
 
 from functools import lru_cache
 from pathlib import Path
 
-from configs.settings import Settings, get_settings
+from configs.settings import Settings
 
 
 @lru_cache()
-def _settings() -> Settings:
-    """Return the cached application settings."""
-
-    return get_settings()
-
-
 def get_data_dir() -> Path:
-    """Directory where datasets are stored."""
-
-    return _settings().data_dir
+    return Settings().data_dir
 
 
+@lru_cache()
 def get_models_dir() -> Path:
-    """Directory containing trained models."""
-
-    return _settings().models_dir
+    return Settings().models_dir
 
 
+@lru_cache()
 def get_logs_dir() -> Path:
-    """Directory used for log files."""
-
-    return _settings().logs_dir
+    return Settings().logs_dir
 
 
+@lru_cache()
 def get_reports_dir() -> Path:
-    """Directory for generated reports."""
-
-    return _settings().reports_dir
+    return Settings().reports_dir
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- implement lagged feature creation and temporal train/test split helpers
- ensure backtest engine and run_backtest handle slippage and write expected reports
- relax CSV loader and add cached environment helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898c754e1788328ae1cfff43e2ebb51